### PR TITLE
docs(agents): clarify pr workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,6 @@
 - 日常对话使用中文。
 - 仅当用户主动指示提交时才可执行 `git commit`；不得主动请求授权，每次提交都需重新取得明确指示，不得沿用既往口头许可。
 - Git Commit Message 使用简洁、精确、描述性强的英文，遵循[语义化提交规范](https://www.conventionalcommits.org/en/v1.0.0/)，且在可行时尽量包含 scope 信息
-- 每次 `git commit` 必须在提交说明末尾追加 `Co-authored-by: Codex <codex@openai.com>`，确保 Codex 作为联合作者记录。
 
 ## 依赖管理
 - 通用原则


### PR DESCRIPTION
Goal: clarify how contributors craft pull requests so reviewers immediately see the core problem being solved.
- Tell authors to lead PR descriptions with the primary objective and ask questions when context is missing
- Document the preferred `gh pr new --body-file -` workflow and note that comparable flags exist for `gh pr edit`
- Reiterate that we should print the final PR URL after creation for easy referencing
