### PR TITLE
feat(github-pr-issue): 新增 PR 上下文脚本

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -6,7 +6,7 @@
 - 运行方式：为脚本添加执行权限（`chmod +x <file.py>`）后直接运行 `./<file.py>`。
 - 命令行参数定义优先使用 Typer，提供更友好的 CLI 体验；输出信息尽量用 rich 提升可读性与美观度；数据校验/模型定义尽量用 pydantic。
 - Typer 应用实例使用小写 `app` 变量名。
-- 当仅定义一个 command 时，调用规则为直接执行脚本并传参，不使用子命令（例如 `tool.py <url>`；避免 `tool.py fetch <url>`）。
+- 当仅定义一个 command 时，用 `typer.run(main)` 作为入口，不使用 Typer 应用实例与子命令；调用时直接执行脚本并传参（例如 `tool.py <url>`；避免 `tool.py fetch <url>`）。
 - 脚本内每个模块、函数与类型都必须包含简短中文文档字符串。
 - 依赖项必须按需添加；移除依赖项的引用后，若确认不再使用，需同步移除该依赖。
 - 脚本完成后优先用 uv 调用 ruff 做质量检查与格式化：`uv run ruff check scripts`；格式化：`uv run ruff format scripts`。对单文件可替换为具体路径。

--- a/skills/github-pr-issue/SKILL.md
+++ b/skills/github-pr-issue/SKILL.md
@@ -5,16 +5,16 @@ description: 查看/更新 GitHub Issue、PR（含评论与 diff），并按团�
 
 # GitHub CLI Skill（Issue/PR）
 
-## GitHub 链接快速查看
-- 进入 Issue 前可先运行 `gh api user --jq '.login'`，确认当前身份以辨识讨论中提到的用户是否就是自己。
+## 链接快速查看
+- 进入 Issue 前先运行 `gh api user --jq '.login'`，确认当前身份以辨识讨论中提到的用户是否就是自己。
 - Issue：`gh issue view <url>`。
-- PR 信息：`gh pr view <url>`，同样使用默认输出即可，必要时可附加 `--files` 等参数按需展开。
+- PR 信息：`gh pr view <url>`；需要文件列表可加 `--files`。
 - PR diff：`gh pr diff <url> --color never`。
 - PR Review / Review Threads / Issue Comments：
-  - 一次性拉取 Review（评审）、Review Threads（代码行内讨论线程）与 Issue Comments（PR 评论）（JSON，推荐）：使用脚本 `./scripts/pr_context.py`。
-    - PR 链接：`./scripts/pr_context.py fetch https://github.com/OWNER/REPO/pull/123`
-    - 默认限制：Review / Review Threads / Issue Comments 各最多返回 20 条；每个 Review Thread 内的 Comments 也最多 20 条。
-    - 使用注意：若某一类返回数量恰好为 20，说明可能存在截断；必要时请改用 `gh api graphql` 做分页拉取。
+  - 一次性拉取 Review / Review Threads / Issue Comments（JSON，推荐）：使用脚本 [pr_context.py](scripts/pr_context.py)。
+    - 在当前 `SKILL.md` 所在目录执行：`./scripts/pr_context.py https://github.com/OWNER/REPO/pull/123`
+    - 默认限制：Review / Review Threads / Issue Comments 各最多 20 条；每个 Review Thread 内的 Comments 也最多 20 条。
+    - 若某一类返回数量恰好为 20，可能截断；必要时改用 `gh api graphql` 分页拉取。
 
 ## 创建 Issue（非交互）
 1. 标题与描述风格同 PR，内容保持简洁清晰。
@@ -27,18 +27,17 @@ description: 查看/更新 GitHub Issue、PR（含评论与 diff），并按团�
 3. Issue 创建成功后，在终端**单独一行**输出 CLI 返回的完整 Issue URL。
 
 ## 创建 PR
-以下标题与描述规范为默认推荐格式；如与团队/仓库/平台等既有约束冲突，以既有约束为准。若有明确要求（如需中文），则优先遵循；未覆盖的部分再按本规范补齐。
+以下标题与描述规范为默认推荐格式；如与团队/仓库/平台等既有约束冲突，以既有约束为准。若有明确要求（如需中文），则优先遵循。
 1. 确认 `git status` 干净，`git push` 到远端。
-2. 标题风格：英文、遵循语义化提交规范（如 `feat(scope): short summary`），保持简洁且描述核心目的；即使标题要求中文，语义化前缀（如 `feat`、`fix`）仍需英文。
-3. 描述风格：英文、短句和项目符号，优先让不看代码的读者也能理解动机与结果。重点是 what/why/impact 和被迫约束，避免流水账与开发过程细节。若上下文不足以明确目标或约束，应主动向开发者确认后再撰写。
+2. 标题风格：英文、遵循语义化提交规范（如 `feat(scope): short summary`），简洁且描述核心目的；即使标题要求中文，语义化前缀仍需英文。
+3. 描述风格：英文、短句和项目符号，突出 what/why/impact 与必要约束，避免流水账。若上下文不足以明确目标或约束，应先向开发者确认。
 4. 期望正文格式（精简但信息完整，按需删减无关块）：
    - `## Summary`：用 1-2 条短句说明“改了什么/影响是什么”与“为什么现在做”。
    - `## Key changes`：3-5 条要点列出主要变更。
    - `## Constraints / tradeoffs`：若存在约束、限制或非理想选择，简要说明。
    - `## Testing`：验证方式、命令或场景；未测试需注明原因。
    - `## Notes`（可选）：reviewers 关注点、发布注意事项或后续计划。
-5. 特别强调：描述应聚焦 PR 合并前后系统的变化与影响，避免记录开发中的中间过程或修改步骤。
-6. 用非交互式命令创建 PR，正文统一通过 `--body-file` 传入：
+5. 用非交互式命令创建 PR，正文统一通过 `--body-file` 传入：
    ```bash
    gh pr new --title "feat(scope): short semantic summary" --body-file - <<'EOF'
    # 按上面的格式填充正文
@@ -46,5 +45,5 @@ description: 查看/更新 GitHub Issue、PR（含评论与 diff），并按团�
    ```
    - 可追加 `--base <branch>`、`--draft` 等参数。
    - 多行正文只能通过 `--body-file` 传入，避免在 `--body` 中写 `\n`。
-7. `gh pr edit` 与 `gh pr new` 参数一致，需修改时复用。
-8. PR 创建成功后，在终端**单独一行**输出 CLI 返回的完整 PR URL。
+6. `gh pr edit` 与 `gh pr new` 参数一致，需修改时复用。
+7. PR 创建成功后，在终端**单独一行**输出 CLI 返回的完整 PR URL。


### PR DESCRIPTION
## 摘要
- 新增脚本统一拉取 PR 的 Review、Review Threads 与 Issue Comments，并包含 PR 正文。
- 精简 skill 文档中的长 GQL 查询，降低上下文占用。
- 规范单命令 Typer 脚本的调用方式。

## 关键变更
- 新增 `skills/github-pr-issue/scripts/pr_context.py`，封装 GraphQL 查询并提供 CLI。
- `skills/github-pr-issue/SKILL.md` 改为引用脚本方式调用，并标注默认 20 条限制与截断提示。
- `scripts/AGENTS.md` 补充 Typer 使用约定（`app` 命名、单命令 `typer.run`）。

## 测试
- 未运行（脚本为 CLI 包装，需实际调用场景验证）。
