### PR TITLE
feat(confluence-cli): 添加附件与页面相关能力

### DIFF
--- a/skills/confluence-cli/SKILL.md
+++ b/skills/confluence-cli/SKILL.md
@@ -13,6 +13,10 @@ description: 查询、检索与阅读 Confluence 文档/页面。
   - `get --page-id [--body-format --expand]`
   - `by-title --space-key --title [--body-format --expand]`
   - `children --page-id [--start --limit --expand]`
+  - `publish-markdown --parent-id --title --markdown-path [--update-if-exists --body-format --expand]`
+- `attachment`
+  - `list --page-id [--start --limit --expand]`
+  - `download --page-id [--output-dir --name --filter --all --start --limit --expand]`
 - `search`
   - `--cql [--start --limit --body-format --expand]`
 
@@ -22,6 +26,14 @@ description: 查询、检索与阅读 Confluence 文档/页面。
 3) 冷门参数/字段怎么查
 - 运行 `./scripts/confluence_cli.py <command> --help` 查看该命令的参数
 - 需要更深入的 Confluence API 字段时，可扩展脚本中的 `expand` 参数
+
+4) 附件下载示例
+- 下载指定附件（可重复传入 `--name`）：`./scripts/confluence_cli.py attachment download --page-id 3060336952 --output-dir ./attachments --name a.png --name b.png`
+- 下载全部附件（自动分页）：`./scripts/confluence_cli.py attachment download --page-id 3060336952 --all --output-dir ./attachments`
+- 过滤下载（正则）：`./scripts/confluence_cli.py attachment download --page-id 3060336952 --filter 'image2026-1-19_.*\\.png' --all --output-dir ./attachments`
+
+5) 发布 Markdown 示例
+- 发布到父页面（同名则更新）：`./scripts/confluence_cli.py --json page publish-markdown --parent-id 3061931928 --title "批量重置 Offset 功能测试" --markdown-path /path/to/doc.md`
 
 ## 资源
 

--- a/skills/confluence-cli/scripts/confluence_api_client.py
+++ b/skills/confluence-cli/scripts/confluence_api_client.py
@@ -99,6 +99,71 @@ class ConfluenceApiClient:
             expand=expand,
         )
 
+    def get_page_attachments(
+        self,
+        page_id: str,
+        start: int = 0,
+        limit: int = 25,
+        expand: str | None = None,
+    ) -> Any:
+        """获取页面附件列表。"""
+        params: dict[str, Any] = {"start": start, "limit": limit}
+        if expand:
+            params["expand"] = expand
+        return self.client.get(
+            f"rest/api/content/{page_id}/child/attachment",
+            params=params,
+        )
+
+    def create_page(
+        self,
+        space_key: str,
+        title: str,
+        body: str,
+        parent_id: str | None = None,
+        representation: str = "storage",
+    ) -> Any:
+        """创建页面。"""
+        return self.client.create_page(
+            space=space_key,
+            title=title,
+            body=body,
+            parent_id=parent_id,
+            representation=representation,
+        )
+
+    def update_page(
+        self,
+        page_id: str,
+        title: str,
+        body: str,
+        parent_id: str | None = None,
+        representation: str = "storage",
+    ) -> Any:
+        """更新页面。"""
+        return self.client.update_page(
+            page_id=page_id,
+            title=title,
+            body=body,
+            parent_id=parent_id,
+            representation=representation,
+        )
+
+    def attach_file(
+        self,
+        page_id: str,
+        file_path: str,
+        title: str | None = None,
+        comment: str | None = None,
+    ) -> Any:
+        """上传附件到页面。"""
+        return self.client.attach_file(
+            filename=file_path,
+            page_id=page_id,
+            title=title,
+            comment=comment,
+        )
+
     def search_cql(
         self,
         cql: str,


### PR DESCRIPTION
## Summary
- 为 Confluence CLI 补充页面创建/更新与附件相关能力的说明与客户端接口。

## Key changes
- 新增 `get_page_attachments`，支持获取页面附件列表。
- 新增 `create_page`/`update_page`，封装页面创建与更新。
- 新增 `attach_file`，支持页面附件上传。
- 在技能文档中补充 `attachment` 与 `publish-markdown` 命令及示例。

## Constraints / tradeoffs
- 未新增兼容旧行为的额外逻辑，仅补充新能力。

## Testing
- 未测试（文档与轻量封装变更）。
