### PR TITLE
docs(skills): 补充脚本调用正反例

### DIFF
--- a/skills/confluence-cli/SKILL.md
+++ b/skills/confluence-cli/SKILL.md
@@ -5,6 +5,16 @@ description: 查询、检索与阅读 Confluence 文档/页面。
 
 说明：以下调用方式均以当前 `SKILL.md` 文件所在文件夹为 workdir。
 
+脚本调用方式（必须直接执行，不要用 `uv run python` 或 `python`）：
+```bash
+cd skills/confluence-cli && ./scripts/confluence_cli.py --json page get --page-id 3060336952
+```
+错误示例：
+```bash
+uv run python skills/confluence-cli/scripts/confluence_cli.py --json page get --page-id 3060336952
+python skills/confluence-cli/scripts/confluence_cli.py --json page get --page-id 3060336952
+```
+
 1) 常用子命令（覆盖日常场景）
 - `space`
   - `list [--start --limit --expand]`

--- a/skills/exa-cli/SKILL.md
+++ b/skills/exa-cli/SKILL.md
@@ -7,6 +7,16 @@ description: 使用 Exa 搜索与代码上下文命令行进行信息检索与�
 
 说明：以下调用方式均以当前 `SKILL.md` 文件所在文件夹为 workdir。必须直接当作可执行文件执行。
 
+脚本调用方式示例（不要用 `uv run python` 或 `python`）：
+```bash
+cd skills/exa-cli && ./scripts/exa-cli.py web-search-exa "site:golang.org context.WithCancel example"
+```
+错误示例：
+```bash
+uv run python skills/exa-cli/scripts/exa-cli.py web-search-exa "site:golang.org context.WithCancel example"
+python skills/exa-cli/scripts/exa-cli.py web-search-exa "site:golang.org context.WithCancel example"
+```
+
 - 运行脚本：`scripts/exa-cli.py`
 - 网页搜索：`scripts/exa-cli.py web-search-exa <query>`
 - 编程检索：`scripts/exa-cli.py get-code-context-exa <query>`

--- a/skills/fetch-url/SKILL.md
+++ b/skills/fetch-url/SKILL.md
@@ -6,6 +6,16 @@ description: 渲染网页 URL，去噪提取正文并输出为 Markdown（默认
 在当前文件所在目录运行：`./scripts/fetch_url.py URL`（仅支持 `http` / `https`）。  
 说明：必须直接当作可执行文件执行。
 
+脚本调用方式示例（不要用 `uv run python` 或 `python`）：
+```bash
+cd skills/fetch-url && ./scripts/fetch_url.py https://example.com --output ./page.md
+```
+错误示例：
+```bash
+uv run python skills/fetch-url/scripts/fetch_url.py https://example.com --output ./page.md
+python skills/fetch-url/scripts/fetch_url.py https://example.com --output ./page.md
+```
+
 默认自动探测本地 Chromium 系浏览器路径；未探测到时需安装 Playwright 浏览器：
 
 ```bash

--- a/skills/github-pr-issue/SKILL.md
+++ b/skills/github-pr-issue/SKILL.md
@@ -12,6 +12,15 @@ description: 查看/更新 GitHub Issue、PR（含评论与 diff），并按团�
   - 建议：查看 PR 时尽量一次性调用该脚本获取所需信息，避免多次调用 `gh` 带来的额外开销。
   - 在当前 `SKILL.md` 所在目录执行：`./scripts/read_pr.py https://github.com/OWNER/REPO/pull/123`
   - 必须直接当作可执行文件执行。
+  - 调用示例（不要用 `uv run python` 或 `python`）：
+    ```bash
+    cd skills/github-pr-issue && ./scripts/read_pr.py https://github.com/OWNER/REPO/pull/123 --with-diff --with-files
+    ```
+  - 错误示例：
+    ```bash
+    uv run python skills/github-pr-issue/scripts/read_pr.py https://github.com/OWNER/REPO/pull/123 --with-diff --with-files
+    python skills/github-pr-issue/scripts/read_pr.py https://github.com/OWNER/REPO/pull/123 --with-diff --with-files
+    ```
   - 可选参数示例：
     - `--with-diff`：包含 diff。
     - `--with-body`：包含 PR body。

--- a/skills/pwdebug/SKILL.md
+++ b/skills/pwdebug/SKILL.md
@@ -12,52 +12,63 @@ description: 用于需要通过命令行操作真实浏览器实例进行前端�
 ## 快速开始
 
 > 工作目录应为本文件所在目录，示例命令默认从该目录执行。
+> 说明：必须直接执行脚本，不要用 `uv run python` 或 `python`。
+
+脚本调用方式示例：
+```bash
+cd skills/pwdebug && ./scripts/pwdebug.py start
+```
+错误示例：
+```bash
+uv run python skills/pwdebug/scripts/pwdebug.py start
+python skills/pwdebug/scripts/pwdebug.py start
+```
 
 1. 启动浏览器服务（常驻进程）：
 
 ```bash
-scripts/pwdebug.py start
+./scripts/pwdebug.py start
 ```
 
 2. 在新标签页打开页面：
 
 ```bash
-scripts/pwdebug.py nav https://example.com --new
+./scripts/pwdebug.py nav https://example.com --new
 ```
 
 3. 执行 JS 表达式：
 
 ```bash
-scripts/pwdebug.py evaluate "document.title"
+./scripts/pwdebug.py evaluate "document.title"
 ```
 
 4. 截图：
 
 ```bash
-scripts/pwdebug.py screenshot --full
+./scripts/pwdebug.py screenshot --full
 ```
 
 5. 交互式拾取元素：
 
 ```bash
-scripts/pwdebug.py pick "点击登录按钮"
+./scripts/pwdebug.py pick "点击登录按钮"
 ```
 
 6. 监听控制台日志：
 
 ```bash
-scripts/pwdebug.py watch-logs
+./scripts/pwdebug.py watch-logs
 ```
 
 7. 查看最近日志：
 
 ```bash
-scripts/pwdebug.py logs 100
+./scripts/pwdebug.py logs 100
 ```
 
 ## 说明
 
-- CLI 入口：`scripts/pwdebug.py`
+- CLI 入口：`./scripts/pwdebug.py`
 - 日志路径：`~/.cache/pwdebug/console.log.jsonl`
 - 状态路径：`~/.cache/pwdebug/server.json`
 

--- a/skills/ticktick-cli/SKILL.md
+++ b/skills/ticktick-cli/SKILL.md
@@ -5,6 +5,16 @@ description: 使用 Python CLI 与 Dida365 Open API 交互以管理滴答清单�
 
 说明：以下调用方式均以当前 `SKILL.md` 文件所在文件夹为 workdir。
 
+脚本调用方式示例（不要用 `uv run python` 或 `python`）：
+```bash
+cd skills/ticktick-cli && ./scripts/ticktick_cli.py --json project list
+```
+错误示例：
+```bash
+uv run python skills/ticktick-cli/scripts/ticktick_cli.py --json project list
+python skills/ticktick-cli/scripts/ticktick_cli.py --json project list
+```
+
 1) 常用子命令（覆盖日常场景）
 - `project`
   - `list`


### PR DESCRIPTION
## Summary
- 为含脚本的 skill 补充统一的正确/错误调用示例，强调必须在目录内直接执行脚本。

## Key changes
- 在多个 skill 文档增加 `cd ... && ./scripts/...` 的正确示例。
- 增加 `uv run python`/`python` 的错误示例以避免误用。
- 统一强调在 `SKILL.md` 所在目录执行脚本。

## Testing
- 未测试（文档变更）。
