### PR TITLE
feat(fetch-url): 默认优先协商 Agent Markdown

### DIFF
--- a/skills/fetch-url/SKILL.md
+++ b/skills/fetch-url/SKILL.md
@@ -27,7 +27,6 @@ uv run playwright install chromium
 - `--timeout-ms`：Playwright 导航超时（毫秒，默认 60000）。
 - `--browser-path`：指定本地 Chromium 系浏览器路径（默认自动探测）。
 - `--output-format`：输出格式（默认 `markdown`），支持 `csv`、`html`、`json`、`markdown`、`raw-html`、`txt`、`xml`、`xmltei`；`raw-html` 直接输出渲染后的 HTML（不经 trafilatura）。
-- `--prefer-agent-markdown/--no-prefer-agent-markdown`：在 `markdown` 输出下，先尝试通过 `Accept: text/markdown` 协商获取原站 Markdown（命中则不再走浏览器渲染），默认开启。
 
 示例：
 

--- a/skills/fetch-url/scripts/fetch_url.py
+++ b/skills/fetch-url/scripts/fetch_url.py
@@ -204,11 +204,6 @@ def fetch(
         "markdown",
         help="Output format: csv, html, json, markdown, raw-html, txt, xml, xmltei.",
     ),
-    prefer_agent_markdown: bool = typer.Option(
-        True,
-        "--prefer-agent-markdown/--no-prefer-agent-markdown",
-        help="For markdown output, first try Accept: text/markdown negotiation before browser rendering.",
-    ),
     verbose: bool = typer.Option(False, "--verbose", help="Print progress and diagnostic logs."),
 ) -> None:
     """通过 Playwright 渲染并用 trafilatura 提取内容。"""
@@ -219,7 +214,7 @@ def fetch(
     resolved_browser_path = str(browser_path) if browser_path else detect_browser_path()
     try:
         content: str | None = None
-        if output_format == "markdown" and prefer_agent_markdown:
+        if output_format == "markdown":
             content = fetch_agent_markdown(url, timeout_ms=timeout_ms, verbose=verbose)
         if content is None:
             html = render_html(


### PR DESCRIPTION
## 摘要
- 为 `fetch-url` 增加对 Cloudflare Markdown for Agents 协商能力的支持，在 `markdown` 输出模式下优先请求 `text/markdown`。
- 保留浏览器渲染提取作为兜底路径，兼顾性能与兼容性。

## 关键改动
- 新增 `fetch_agent_markdown()`：发送 `Accept: text/markdown` 请求并在命中时直接返回原始 Markdown。
- 调整主流程：`output_format=markdown` 时默认先走协商，失败后再回退到 Playwright + `trafilatura`。
- 增强脚本日志与渲染稳定性策略（`domcontentloaded` + `load` + 短暂 DOM 稳定检测）。
- 移除 `--prefer-agent-markdown/--no-prefer-agent-markdown`，避免额外配置分支。
- 更新 skill 文档，补充新行为与参数说明。

## 约束 / 取舍
- 仅当输出格式为 `markdown` 时尝试协商；其他格式仍走原有渲染提取流程。
- 若站点不支持 `text/markdown` 或协商失败，会自动回退，不影响可用性。

## 测试
- `./scripts/fetch_url.py --help`
- `./scripts/fetch_url.py https://blog.cloudflare.com/markdown-for-agents/ --verbose --output /tmp/markdown_for_agents.md`
- 验证日志出现 `Negotiated content-type text/markdown` 与 `Markdown for Agents hit`。

## 兼容性说明
- BREAKING CHANGE：移除了 CLI 开关 `--prefer-agent-markdown/--no-prefer-agent-markdown`。
- 现在 `markdown` 输出下固定优先协商 `text/markdown`，无法通过参数关闭该行为。
