### PR TITLE
feat: 将 prompts 仓库声明为 dcjanus-personal plugin

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "prompts-personal",
   "version": "0.1.0",
-  "description": "DCjanus personal Codex skills and prompt helpers.",
+  "description": "DCjanus 的个人 skill 集合。",
   "skills": "./skills",
   "interface": {
     "displayName": "Prompts Personal",
-    "shortDescription": "Personal Codex skills and prompt helpers.",
-    "longDescription": "Personal Codex skill collection for day-to-day engineering, research, and local workflow automation.",
+    "shortDescription": "DCjanus 的个人 skill 集合。",
+    "longDescription": "收纳 DCjanus 日常在 Codex 中使用的个人 skills 与相关提示词。",
     "developerName": "DCjanus",
     "category": "Productivity",
     "capabilities": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
-  "name": "prompts-personal",
+  "name": "dcjanus-personal",
   "version": "0.1.0",
   "description": "DCjanus 的个人 skill 集合。",
   "skills": "./skills",
   "interface": {
-    "displayName": "Prompts Personal",
+    "displayName": "DCjanus Personal",
     "shortDescription": "DCjanus 的个人 skill 集合。",
     "longDescription": "收纳 DCjanus 日常在 Codex 中使用的个人 skills 与相关提示词。",
     "developerName": "DCjanus",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "prompts-personal",
+  "version": "0.1.0",
+  "description": "DCjanus personal Codex skills and prompt helpers.",
+  "skills": "./skills",
+  "interface": {
+    "displayName": "Prompts Personal",
+    "shortDescription": "Personal Codex skills and prompt helpers.",
+    "longDescription": "Personal Codex skill collection for day-to-day engineering, research, and local workflow automation.",
+    "developerName": "DCjanus",
+    "category": "Productivity",
+    "capabilities": [
+      "Skills"
+    ],
+    "defaultPrompt": [
+      "Use my personal Codex skills for this task.",
+      "Prefer my local prompt helpers when they fit the request."
+    ]
+  }
+}


### PR DESCRIPTION
## 为什么

- 这个仓库现在主要承载 DCjanus 日常在 Codex 中使用的个人 skills 与提示词，适合直接声明成一个可安装的 personal plugin。
- 先补齐最小 plugin manifest 后，后续可以在不同设备上用统一方式挂载和启用。

## 改了什么

- 新增 `.codex-plugin/plugin.json`，把当前仓库声明为 `dcjanus-personal` plugin。
- 补充基础 `interface` 元数据与 `version` 字段，便于后续做本地安装和缓存刷新。
- 调整 plugin 名称与展示名称，使其更贴近当前用途和维护方式。

## Validation

- `jq empty .codex-plugin/plugin.json`

## Notes

- 这个 PR 只完成仓库内的 plugin 声明，不包含 home marketplace、本机 `config.toml` 或安装脚本等本地配置。
