### PR TITLE
docs(git-commit): 重组默认提交流程

### DIFF
--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -3,14 +3,6 @@ name: git-commit
 description: 处理 git 提交/推送/分支命名与提交信息规范；当任务涉及 commit、push、起分支或整理 commit message 时使用。
 ---
 
-## 核心原则
-
-- 默认只提交当前任务负责的路径。
-- 创建提交默认使用 `git commit --only -- <paths-owned-by-current-task>`，显式指定本次提交范围，不依赖暂存区。
-- 不要为了提交当前任务去清理、reset、restore 或 stash 无关改动。
-- 如果同一个文件里混有用户或其他 Agent 的改动，先停止并说明情况，不要强行提交。
-- 如果仓库或用户有额外限制，例如受保护分支、发布流程、禁止自动推送，先遵循这些限制。
-
 ## 标准流程
 
 1. 确认当前状态，并确定本次任务负责的路径。
@@ -55,6 +47,8 @@ git show --name-status --oneline --no-renames HEAD
 - `<paths-owned-by-current-task>` 可以是文件，也可以是当前任务完整负责的目录。
 - 大量生成文件优先传目录，例如 `gen/`，不要把几千个文件展开成命令参数。
 - 如果目录里混有无关改动，不要传整个目录，改用更精确的文件或子目录路径。
+- 如果同一个文件里混有用户或其他 Agent 的改动，先停止并说明情况，不要强行提交。
+- 不要为了提交当前任务去清理、reset、restore 或 stash 无关改动。
 - 默认不需要提前 `git add`；`git commit --only -- <paths>` 会直接提交这些路径的当前工作区内容。
 
 ## 提交信息
@@ -68,6 +62,7 @@ git show --name-status --oneline --no-renames HEAD
 
 ## 分支、推送和 PR
 
+- 如果仓库或用户有额外限制，例如受保护分支、发布流程、禁止自动推送，先遵循这些限制。
 - 日常切换分支优先使用 `git switch`，恢复工作区或暂存区优先使用 `git restore`，尽量避免 `git checkout`。
 - 创建分支时尽量遵循 [Conventional Branch](https://conventional-branch.github.io/)；Codex 创建分支默认使用 `codex/` 前缀。
 - 涉及真实 index / 引用的 Git 写操作时默认串行执行，不并行调用多个 `git commit`、`git push` 或其他写操作。

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -3,14 +3,28 @@ name: git-commit
 description: 处理 git 提交/推送/分支命名与提交信息规范；当任务涉及 commit、push、起分支或整理 commit message 时使用。
 ---
 
-## 使用约定
+## 核心原则
 
-说明：以下调用方式均以当前 `SKILL.md` 文件所在文件夹为 workdir。
+- 默认只提交当前任务负责的路径。
+- 创建提交默认使用 `git commit --only -- <paths-owned-by-current-task>`，显式指定本次提交范围，不依赖暂存区。
+- 不要为了提交当前任务去清理、reset、restore 或 stash 无关改动。
+- 如果同一个文件里混有用户或其他 Agent 的改动，先停止并说明情况，不要强行提交。
+- 如果仓库或用户有额外限制，例如受保护分支、发布流程、禁止自动推送，先遵循这些限制。
 
-脚本调用方式（必须直接当作可执行命令运行，不要用 `uv run python` 或 `python`）：
+## 标准流程
+
+1. 确认当前状态，并确定本次任务负责的路径。
 
 ```bash
-cd skills/git-commit && ./scripts/codex_git_commit.py
+git status -sb
+```
+
+2. 获取 `Assisted-by` 信息。
+
+`<skill_dir>` 是当前 `SKILL.md` 文件所在文件夹。脚本必须直接当作可执行命令运行，不要用 `uv run python` 或 `python`。
+
+```bash
+(cd <skill_dir> && ./scripts/codex_git_commit.py)
 ```
 
 错误示例：
@@ -20,48 +34,42 @@ uv run python skills/git-commit/scripts/codex_git_commit.py
 python skills/git-commit/scripts/codex_git_commit.py
 ```
 
-### 先确认范围与限制
+3. 创建提交。
 
-- 确认当前仓库或用户没有额外限制，例如受保护分支、发布流程、禁止自动推送。
-- 不确定应提交哪些改动、推送到哪个远端或分支、是否会影响共享分支时，先澄清。
-- 提交前确认工作区中哪些改动属于当前任务，不要混入无关改动。
+```bash
+git commit --only \
+  -m "type(scope): concise summary" \
+  -m "Assisted-by: <agent-name>:<model-name>" \
+  -- <paths-owned-by-current-task>
+```
 
-### 提交信息与分支命名
+4. 核对提交范围。
+
+```bash
+git show --name-status --oneline --no-renames HEAD
+```
+
+## 路径选择
+
+- `<paths-owned-by-current-task>` 必须只包含当前任务负责的文件或目录；多个 Agent 共用同一个 worktree 时也按这个规则执行。
+- `<paths-owned-by-current-task>` 可以是文件，也可以是当前任务完整负责的目录。
+- 大量生成文件优先传目录，例如 `gen/`，不要把几千个文件展开成命令参数。
+- 如果目录里混有无关改动，不要传整个目录，改用更精确的文件或子目录路径。
+- 默认不需要提前 `git add`；`git commit --only -- <paths>` 会直接提交这些路径的当前工作区内容。
+
+## 提交信息
 
 - 提交信息使用简洁、精确的英文。
 - 推荐格式：`type(scope): short summary`，遵循 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)。
 - 常见 `type`：`feat`、`fix`、`refactor`、`docs`、`test`、`chore`
 - `summary` 保持简短，聚焦结果；若无合适 scope，可省略。
-- 创建分支时尽量遵循 [Conventional Branch](https://conventional-branch.github.io/)。
+- 若提交内容存在 AI 编码助手的实质性参与，追加 `Assisted-by: <agent-name>:<model-name>` trailer。
+- 用 shell 执行 `git commit -m ...` 时，不要在提交标题或正文里直接放未转义的反引号 `` ` ``。
 
-### Assisted-by
-
-- 若提交内容存在 AI 编码助手的实质性参与，追加 `Assisted-by:` trailer。
-- 在 Codex 场景下，先直接执行本 skill 下的 [codex_git_commit.py](scripts/codex_git_commit.py)，再用脚本返回的 agent 名和模型名补充 `Assisted-by:`。
-- 推荐格式：`Assisted-by: <agent-name>:<model-name>`
-- 方括号只是占位说明，不是字面量。
-
-### Git 执行方式
+## 分支、推送和 PR
 
 - 日常切换分支优先使用 `git switch`，恢复工作区或暂存区优先使用 `git restore`，尽量避免 `git checkout`。
-- 涉及真实 index / 引用的 Git 写操作时默认串行执行，不并行调用多个 `git add`、`git commit`、`git push`。
-- 如需连续执行 `git add`、`git commit`、`git push`，按顺序逐条执行，前一步成功后再执行下一步。
+- 创建分支时尽量遵循 [Conventional Branch](https://conventional-branch.github.io/)；Codex 创建分支默认使用 `codex/` 前缀。
+- 涉及真实 index / 引用的 Git 写操作时默认串行执行，不并行调用多个 `git commit`、`git push` 或其他写操作。
 - 如果遇到 `.git/index.lock`，先判断是否有其他活跃 Git 进程。
-- 用 shell 执行 `git commit -m ...` 时，不要在提交标题或正文里直接放未转义的反引号 `` ` ``。
-- 创建提交默认使用 `git commit --only -- <paths-owned-by-current-task>`，显式指定本次提交的文件列表，不依赖暂存区。
-- `<paths-owned-by-current-task>` 必须只包含当前任务负责的文件；多个 Agent 共用同一个 worktree 时也按这个规则执行。
-- `<paths-owned-by-current-task>` 可以是文件，也可以是当前任务完整负责的目录；大量生成文件优先传目录，不要把几千个文件展开成命令参数。
-- 不要为了提交当前任务去清理、reset、restore 或 stash 无关文件。
-- 默认不需要提前 `git add`；`git commit --only -- <paths>` 会直接提交这些路径的当前工作区内容。
-- 如果同一个文件里混有用户或其他 Agent 的改动，先停止并说明情况，不要强行提交。
-
-## 示例
-
-- 创建提交：
-
-```bash
-git status -sb
-(cd <skill_dir> && ./scripts/codex_git_commit.py)
-git commit --only -m "fix(scope): concise summary" -m "Assisted-by: <agent-name>:<model-name>" -- <paths>
-git show --name-status --oneline --no-renames HEAD
-```
+- 推送或创建 PR 前，使用 `git status -sb` 确认本次提交、分支和工作区状态符合预期。

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -48,33 +48,10 @@ python skills/git-commit/scripts/codex_git_commit.py
 - 如需连续执行 `git add`、`git commit`、`git push`，按顺序逐条执行，前一步成功后再执行下一步。
 - 如果遇到 `.git/index.lock`，先判断是否有其他活跃 Git 进程。
 - 用 shell 执行 `git commit -m ...` 时，不要在提交标题或正文里直接放未转义的反引号 `` ` ``。
-
-### 选择性提交
-
-默认使用 `git commit --only` 做选择性提交，不依赖暂存区，避免混入无关文件。
-
-推荐流程：
-
-```bash
-git status -sb
-git diff --name-only
-
-(cd <skill_dir> && ./scripts/codex_git_commit.py)
-
-git commit --only \
-  -m "type(scope): concise summary" \
-  -m "Assisted-by: <agent-name>:<model-name>" \
-  -- <paths-owned-by-current-task>
-
-git show --name-status --oneline --no-renames HEAD
-```
-
-要求：
-
-- `<paths-owned-by-current-task>` 必须只包含当前任务负责的文件。
+- 创建提交默认使用 `git commit --only -- <paths-owned-by-current-task>`，显式指定本次提交的文件列表，不依赖暂存区。
+- `<paths-owned-by-current-task>` 必须只包含当前任务负责的文件；多个 Agent 共用同一个 worktree 时也按这个规则执行。
 - 不要为了提交当前任务去清理、reset、restore 或 stash 无关文件。
 - 默认不需要提前 `git add`；`git commit --only -- <paths>` 会直接提交这些路径的当前工作区内容。
-- 多个 Agent 共用同一个 worktree 时，也按这个流程执行。
 - 如果同一个文件里混有用户或其他 Agent 的改动，先停止并说明情况，不要强行提交。
 
 ## 示例
@@ -83,6 +60,8 @@ git show --name-status --oneline --no-renames HEAD
 
 ```bash
 git status -sb
+git diff --name-only
 (cd <skill_dir> && ./scripts/codex_git_commit.py)
 git commit --only -m "fix(scope): concise summary" -m "Assisted-by: <agent-name>:<model-name>" -- <paths>
+git show --name-status --oneline --no-renames HEAD
 ```

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -61,7 +61,6 @@ python skills/git-commit/scripts/codex_git_commit.py
 
 ```bash
 git status -sb
-git diff --name-only
 (cd <skill_dir> && ./scripts/codex_git_commit.py)
 git commit --only -m "fix(scope): concise summary" -m "Assisted-by: <agent-name>:<model-name>" -- <paths>
 git show --name-status --oneline --no-renames HEAD

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -49,9 +49,9 @@ python skills/git-commit/scripts/codex_git_commit.py
 - 如果遇到 `.git/index.lock`，先判断是否有其他活跃 Git 进程。
 - 用 shell 执行 `git commit -m ...` 时，不要在提交标题或正文里直接放未转义的反引号 `` ` ``。
 
-### 多 Agent 共用 worktree 时的选择性提交
+### 选择性提交
 
-当同一个 worktree 里可能存在其他 Agent 或用户的未提交改动时，默认使用 `git commit --only` 做选择性提交，不依赖暂存区。
+默认使用 `git commit --only` 做选择性提交，不依赖暂存区，避免混入无关文件。
 
 推荐流程：
 
@@ -74,6 +74,7 @@ git show --name-status --oneline --no-renames HEAD
 - `<paths-owned-by-current-task>` 必须只包含当前任务负责的文件。
 - 不要为了提交当前任务去清理、reset、restore 或 stash 无关文件。
 - 默认不需要提前 `git add`；`git commit --only -- <paths>` 会直接提交这些路径的当前工作区内容。
+- 多个 Agent 共用同一个 worktree 时，也按这个流程执行。
 - 如果同一个文件里混有用户或其他 Agent 的改动，先停止并说明情况，不要强行提交。
 
 ## 示例

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -50,6 +50,7 @@ python skills/git-commit/scripts/codex_git_commit.py
 - 用 shell 执行 `git commit -m ...` 时，不要在提交标题或正文里直接放未转义的反引号 `` ` ``。
 - 创建提交默认使用 `git commit --only -- <paths-owned-by-current-task>`，显式指定本次提交的文件列表，不依赖暂存区。
 - `<paths-owned-by-current-task>` 必须只包含当前任务负责的文件；多个 Agent 共用同一个 worktree 时也按这个规则执行。
+- `<paths-owned-by-current-task>` 可以是文件，也可以是当前任务完整负责的目录；大量生成文件优先传目录，不要把几千个文件展开成命令参数。
 - 不要为了提交当前任务去清理、reset、restore 或 stash 无关文件。
 - 默认不需要提前 `git add`；`git commit --only -- <paths>` 会直接提交这些路径的当前工作区内容。
 - 如果同一个文件里混有用户或其他 Agent 的改动，先停止并说明情况，不要强行提交。

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -49,58 +49,32 @@ python skills/git-commit/scripts/codex_git_commit.py
 - 如果遇到 `.git/index.lock`，先判断是否有其他活跃 Git 进程。
 - 用 shell 执行 `git commit -m ...` 时，不要在提交标题或正文里直接放未转义的反引号 `` ` ``。
 
-### 多 Agent 并行提交时的隔离方案
+### 多 Agent 共用 worktree 时的选择性提交
 
-当多个 Agent 可能同时在同一个 worktree 里准备提交时，提交阶段用仓库级锁串行化，仍然走普通 `git commit --only`。
+当同一个 worktree 里可能存在其他 Agent 或用户的未提交改动时，默认使用 `git commit --only` 做选择性提交，不依赖暂存区。
 
 推荐流程：
 
 ```bash
 git status -sb
 git diff --name-only
-git diff --cached --name-only
 
-(
-  lock_dir="$(git rev-parse --git-path codex-commit.lock.d)"
-  while ! mkdir "$lock_dir" 2>/dev/null; do
-    sleep 1
-  done
-  trap 'rmdir "$lock_dir"' EXIT
+(cd <skill_dir> && ./scripts/codex_git_commit.py)
 
-  git status -sb
-  git diff --cached --name-only
+git commit --only \
+  -m "type(scope): concise summary" \
+  -m "Assisted-by: <agent-name>:<model-name>" \
+  -- <paths-owned-by-current-task>
 
-  git add -- <paths-owned-by-current-task>
-
-  (cd <skill_dir> && ./scripts/codex_git_commit.py)
-
-  git commit --only \
-    -m "type(scope): concise summary" \
-    -m "Assisted-by: <agent-name>:<model-name>" \
-    -- <paths-owned-by-current-task>
-
-  git show --name-status --oneline --no-renames HEAD
-)
+git show --name-status --oneline --no-renames HEAD
 ```
 
 要求：
 
 - `<paths-owned-by-current-task>` 必须只包含当前任务负责的文件。
-- 只有加锁后的提交阶段可以写真实 index；读代码、改文件、跑测试不需要持有这把锁。
-- 锁目录通过 `git rev-parse --git-path` 放在当前仓库的 `.git` 目录下；如果上一次进程异常退出留下锁目录，确认没有其他提交进程后再手工删除。
-- 如果真实暂存区已有无关文件，不要执行 `git restore --staged :/` 这类全局操作。
-- 如果当前任务文件里混有用户或其他 Agent 的改动，先停止并说明冲突，不要强行拆提交。
-- 如果 `git commit --only` 因为 `HEAD` 已变化而无法直接提交，重新检查当前任务 diff，确认仍然只包含自己的改动后再重试。
-
-如果确认只有一个 Agent 在操作当前 worktree，也可以使用普通流程：
-
-```bash
-git add -- <paths-owned-by-current-task>
-git commit --only \
-  -m "type(scope): concise summary" \
-  -m "Assisted-by: <agent-name>:<model-name>" \
-  -- <paths-owned-by-current-task>
-```
+- 不要为了提交当前任务去清理、reset、restore 或 stash 无关文件。
+- 默认不需要提前 `git add`；`git commit --only -- <paths>` 会直接提交这些路径的当前工作区内容。
+- 如果同一个文件里混有用户或其他 Agent 的改动，先停止并说明情况，不要强行提交。
 
 ## 示例
 
@@ -108,7 +82,6 @@ git commit --only \
 
 ```bash
 git status -sb
-git add <paths>
 (cd <skill_dir> && ./scripts/codex_git_commit.py)
-git commit -m "fix(scope): concise summary" -m "Assisted-by: <agent-name>:<model-name>"
+git commit --only -m "fix(scope): concise summary" -m "Assisted-by: <agent-name>:<model-name>" -- <paths>
 ```

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -44,10 +44,63 @@ python skills/git-commit/scripts/codex_git_commit.py
 ### Git 执行方式
 
 - 日常切换分支优先使用 `git switch`，恢复工作区或暂存区优先使用 `git restore`，尽量避免 `git checkout`。
-- 涉及 Git 写操作时默认串行执行，不并行调用多个 `git add`、`git commit`、`git push` 或其他会写入 index / 引用的命令。
+- 涉及真实 index / 引用的 Git 写操作时默认串行执行，不并行调用多个 `git add`、`git commit`、`git push`。
 - 如需连续执行 `git add`、`git commit`、`git push`，按顺序逐条执行，前一步成功后再执行下一步。
 - 如果遇到 `.git/index.lock`，先判断是否有其他活跃 Git 进程。
 - 用 shell 执行 `git commit -m ...` 时，不要在提交标题或正文里直接放未转义的反引号 `` ` ``。
+
+### 多 Agent 并行提交时的隔离方案
+
+当多个 Agent 可能同时在同一个 worktree 里准备提交时，提交阶段用仓库级锁串行化，仍然走普通 `git commit --only`。
+
+推荐流程：
+
+```bash
+git status -sb
+git diff --name-only
+git diff --cached --name-only
+
+(
+  lock_dir="$(git rev-parse --git-path codex-commit.lock.d)"
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    sleep 1
+  done
+  trap 'rmdir "$lock_dir"' EXIT
+
+  git status -sb
+  git diff --cached --name-only
+
+  git add -- <paths-owned-by-current-task>
+
+  (cd <skill_dir> && ./scripts/codex_git_commit.py)
+
+  git commit --only \
+    -m "type(scope): concise summary" \
+    -m "Assisted-by: <agent-name>:<model-name>" \
+    -- <paths-owned-by-current-task>
+
+  git show --name-status --oneline --no-renames HEAD
+)
+```
+
+要求：
+
+- `<paths-owned-by-current-task>` 必须只包含当前任务负责的文件。
+- 只有加锁后的提交阶段可以写真实 index；读代码、改文件、跑测试不需要持有这把锁。
+- 锁目录通过 `git rev-parse --git-path` 放在当前仓库的 `.git` 目录下；如果上一次进程异常退出留下锁目录，确认没有其他提交进程后再手工删除。
+- 如果真实暂存区已有无关文件，不要执行 `git restore --staged :/` 这类全局操作。
+- 如果当前任务文件里混有用户或其他 Agent 的改动，先停止并说明冲突，不要强行拆提交。
+- 如果 `git commit --only` 因为 `HEAD` 已变化而无法直接提交，重新检查当前任务 diff，确认仍然只包含自己的改动后再重试。
+
+如果确认只有一个 Agent 在操作当前 worktree，也可以使用普通流程：
+
+```bash
+git add -- <paths-owned-by-current-task>
+git commit --only \
+  -m "type(scope): concise summary" \
+  -m "Assisted-by: <agent-name>:<model-name>" \
+  -- <paths-owned-by-current-task>
+```
 
 ## 示例
 


### PR DESCRIPTION
## Why

- `git-commit` skill 经过多轮调整后，结构开始偏碎，不利于人类和 Agent 快速理解默认提交流程。
- 需要保留一套简单、稳定、可直接执行的最佳实践：默认显式指定提交路径。

## What

- 重组为“核心原则、标准流程、路径选择、提交信息、分支推送 PR”五个部分。
- 将 `git commit --only -- <paths>` 作为默认提交方式，要求显式指定当前任务负责的文件或目录。
- 补充大量生成文件优先传目录、同文件混合修改时停止说明等边界规则。

## Validation

- 本地使用重组后的 `git commit --only -- skills/git-commit/SKILL.md` 流程完成提交。
