### PR TITLE
feat(confluence-cli): 支持重命名页面

### DIFF
--- a/skills/confluence-cli/SKILL.md
+++ b/skills/confluence-cli/SKILL.md
@@ -23,6 +23,7 @@ python skills/confluence-cli/scripts/confluence_cli.py --json page get --page-id
   - `get --page-id [--body-format --expand --fresh]`
   - `by-title --space-key --title [--body-format --expand]`
   - `children --page-id [--start --limit --expand]`
+  - `rename --page-id --title`
   - `publish-markdown --parent-id --title --markdown-path [--update-if-exists --body-format --expand]`
 - `attachment`
   - `list --page-id [--start --limit --expand]`

--- a/skills/confluence-cli/scripts/confluence_api_client.py
+++ b/skills/confluence-cli/scripts/confluence_api_client.py
@@ -225,6 +225,50 @@ class ConfluenceApiClient:
             f"rest/api/content/{page_id}", json_data=data, params={"status": "current"}
         )
 
+    def rename_page(
+        self,
+        page_id: str,
+        title: str,
+        representation: str = "storage",
+    ) -> Any:
+        """重命名页面，并保留当前正文和父页面。"""
+        # 重命名依赖最新 version 和正文，避免用到 Confluence 或代理缓存的旧页面。
+        current = self.get_page(
+            page_id,
+            expand=f"version,body.{representation},ancestors",
+            fresh=True,
+        )
+        version = current.get("version", {}).get("number")
+        if not isinstance(version, int):
+            raise ConfluenceApiError(
+                f"Failed to resolve current page version for {page_id}"
+            )
+
+        body_node = current.get("body", {}).get(representation, {})
+        body = body_node.get("value")
+        if not isinstance(body, str):
+            raise ConfluenceApiError(
+                f"Failed to resolve current page {representation} body for {page_id}"
+            )
+
+        data: dict[str, Any] = {
+            "id": page_id,
+            "type": "page",
+            "title": title,
+            "version": {"number": version + 1},
+            "body": self._encode_body(body, representation),
+        }
+
+        ancestors = current.get("ancestors")
+        if isinstance(ancestors, list) and ancestors:
+            parent_id = ancestors[-1].get("id")
+            if parent_id:
+                data["ancestors"] = [{"type": "page", "id": str(parent_id)}]
+
+        return self._put(
+            f"rest/api/content/{page_id}", json_data=data, params={"status": "current"}
+        )
+
     def attach_file(
         self,
         page_id: str,

--- a/skills/confluence-cli/scripts/confluence_cli.py
+++ b/skills/confluence-cli/scripts/confluence_cli.py
@@ -1074,6 +1074,25 @@ def get_page_children(
     ensure_json_output(payload, state.json_output, render_page_list)
 
 
+@page_app.command("rename")
+def rename_page(
+    ctx: typer.Context,
+    page_id: str = typer.Option(..., "--page-id", help="页面 ID。"),
+    title: str = typer.Option(..., "--title", help="新的页面标题。"),
+) -> None:
+    """重命名页面，保留当前正文和父页面。"""
+    state = ctx.obj
+    if not isinstance(state, AppState):
+        raise ApiError("App config not initialized.")
+    client = get_client(state)
+    payload = client.rename_page(
+        page_id=page_id,
+        title=title,
+        representation=BodyFormat.storage.value,
+    )
+    ensure_json_output(payload, state.json_output)
+
+
 @attachment_app.command("list")
 def list_attachments(
     ctx: typer.Context,


### PR DESCRIPTION
## 背景

`confluence-cli` 已经支持读取和发布页面，但缺少直接重命名页面的命令。

此前需要临时调用 API client 或重新发布页面才能改标题，操作不够直观。

## 改动

- 新增 `page rename --page-id --title` 命令。
- API client 新增 `rename_page()`，通过 Confluence 既有 `PUT /rest/api/content/{id}` 更新标题。
- 重命名前会 fresh 读取当前页面的 `version`、`body.storage` 和 `ancestors`，避免使用缓存页面，并在更新时保留正文和父页面。
- 更新 `confluence-cli` skill 文档中的常用命令列表。

## 验证

- `./scripts/confluence_cli.py page rename --help`
- `uvx ruff format --check skills/confluence-cli/scripts/confluence_api_client.py skills/confluence-cli/scripts/confluence_cli.py`
- `uvx ruff check skills/confluence-cli/scripts/confluence_api_client.py skills/confluence-cli/scripts/confluence_cli.py`

没有为该薄 API 封装新增测试；主要风险点是避免缓存读取、保留正文和父页面，已在实现里显式处理。
