### PR TITLE
fix(gitlab-cli)!: 使用源分支校验 MR CI lint

### DIFF
--- a/skills/gitlab-cli/SKILL.md
+++ b/skills/gitlab-cli/SKILL.md
@@ -110,6 +110,7 @@ glab ci trace test --pipeline-id 123456 --branch main
 ## 脚本支持的场景
 
 - GitLab CI lint：校验本地 `.gitlab-ci.yml`，支持 `--dry-run`、`--include-jobs`、`--ref`、`--json`。
+  - `--dry-run --ref refs/merge-requests/<iid>/head` 会改用 MR source branch 调用 CI Lint。调用方知道源分支时可显式传 `--source-branch <branch>`；否则脚本会根据 ref 里的 MR IID 查询 MR 元数据。部分 GitLab 14.x 实例会因为 MR internal ref 缺少 `source_branch` 在 CI Lint dry-run 返回 500，所以脚本避免直接把 MR internal ref 发给 CI Lint。
 - MR create：非交互创建 MR，可配合 `--cwd`、`--hostname`、`--project` 使用。
 - MR update：非交互更新 MR 标题、正文、labels、reviewers、assignees、milestone、merge 相关选项。
 - Issue create：非交互创建 Issue，可设置正文、labels、assignees、milestone、confidential、due date。
@@ -126,6 +127,8 @@ glab ci trace test --pipeline-id 123456 --branch main
 ```bash
 ./scripts/gitlab_cli.py ci lint --cwd /path/to/repo
 ./scripts/gitlab_cli.py ci lint --cwd /path/to/repo --project group/project --ref main --dry-run --include-jobs
+./scripts/gitlab_cli.py ci lint --cwd /path/to/repo --project 122477 --ref refs/merge-requests/9/head --dry-run
+./scripts/gitlab_cli.py ci lint --cwd /path/to/repo --project 122477 --ref refs/merge-requests/9/head --source-branch chore/sync-knots-api-master --dry-run
 ```
 
 - 创建 MR：

--- a/skills/gitlab-cli/scripts/gitlab_cli.py
+++ b/skills/gitlab-cli/scripts/gitlab_cli.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Literal
@@ -283,6 +284,37 @@ def print_ci_result(payload: dict[str, object], show_merged_yaml: bool) -> None:
             console.print(merged_yaml.rstrip())
 
 
+def parse_merge_request_ref(ref: str) -> int | None:
+    """从 GitLab MR internal ref 中解析 MR IID。"""
+
+    match = re.fullmatch(r"refs/merge-requests/(\d+)/(?:head|merge)", ref)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def resolve_merge_request_source_branch(
+    *,
+    project: str | None,
+    iid: int,
+    cwd: Path,
+    hostname: str | None,
+) -> str:
+    """读取 MR source_branch，用于避开 CI Lint dry-run 对 MR internal ref 的兼容问题。"""
+
+    response = run_glab_api(
+        endpoint=project_endpoint(project, f"merge_requests/{iid}"),
+        method="GET",
+        payload=None,
+        cwd=cwd,
+        hostname=hostname,
+    )
+    source_branch = response.get("source_branch")
+    if not isinstance(source_branch, str) or not source_branch:
+        raise RuntimeError(f"failed to resolve source_branch for merge request !{iid}")
+    return source_branch
+
+
 def print_resource_result(resource_name: str, payload: dict[str, object]) -> None:
     """输出 MR / Issue 创建或更新结果。"""
 
@@ -329,6 +361,11 @@ def ci_lint(
     ),
     include_jobs: bool = typer.Option(False, "--include-jobs", help="返回 jobs 列表。"),
     ref: str | None = typer.Option(None, "--ref", help="dry-run 时使用的分支或 tag。"),
+    source_branch: str | None = typer.Option(
+        None,
+        "--source-branch",
+        help="--ref 为 MR internal ref 时可显式传入；未传时脚本会按 MR IID 查询。",
+    ),
     show_merged_yaml: bool = typer.Option(
         False, "--show-merged-yaml", help="同时输出 merged_yaml。"
     ),
@@ -337,11 +374,27 @@ def ci_lint(
     """校验本地 `.gitlab-ci.yml`。"""
 
     try:
+        effective_ref = ref
+        mr_iid = parse_merge_request_ref(ref) if dry_run and ref else None
+        if mr_iid is not None:
+            if not source_branch:
+                source_branch = resolve_merge_request_source_branch(
+                    project=project,
+                    iid=mr_iid,
+                    cwd=cwd,
+                    hostname=hostname,
+                )
+            effective_ref = source_branch
+            if not as_json:
+                console.print(
+                    f"using source branch {effective_ref!r} for MR internal ref {ref!r}"
+                )
+
         payload = {
             "content": read_text(path),
             "dry_run": dry_run,
             "include_jobs": include_jobs,
-            "ref": ref,
+            "ref": effective_ref,
         }
         response = run_glab_api(
             endpoint=project_endpoint(project, "ci/lint"),
@@ -355,9 +408,9 @@ def ci_lint(
         if dry_run and ref and ref.startswith("refs/merge-requests/"):
             error_console.print(
                 "hint: GitLab CI Lint dry-run may fail on merge request internal "
-                "refs even when the real MR pipeline can be created. Retry with "
-                "the source branch ref to separate YAML validation from GitLab "
-                "MR-ref simulation issues."
+                "refs when GitLab cannot resolve source_branch. Pass "
+                "--source-branch explicitly, or let this tool resolve the MR "
+                "source branch before linting."
             )
         raise typer.Exit(code=1) from exc
 

--- a/skills/gitlab-cli/scripts/tests/test_gitlab_cli.py
+++ b/skills/gitlab-cli/scripts/tests/test_gitlab_cli.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "gitlab_cli.py"
+SPEC = importlib.util.spec_from_file_location("gitlab_cli", SCRIPT_PATH)
+assert SPEC is not None
+gitlab_cli = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(gitlab_cli)
+
+
+def test_parse_merge_request_ref() -> None:
+    assert gitlab_cli.parse_merge_request_ref("refs/merge-requests/9/head") == 9
+    assert gitlab_cli.parse_merge_request_ref("refs/merge-requests/9/merge") == 9
+    assert gitlab_cli.parse_merge_request_ref("refs/heads/main") is None
+
+
+def test_ci_lint_resolves_merge_request_ref_to_source_branch(
+    monkeypatch, tmp_path: Path
+) -> None:
+    ci_file = tmp_path / ".gitlab-ci.yml"
+    ci_file.write_text("test:\n  script: echo ok\n", encoding="utf-8")
+    lint_payloads: list[dict[str, object] | None] = []
+
+    def fake_run_glab_api(
+        *,
+        endpoint: str,
+        method: str,
+        payload: dict[str, object] | None,
+        cwd: Path,
+        hostname: str | None,
+    ) -> dict[str, object]:
+        assert cwd == tmp_path
+        assert hostname is None
+
+        if endpoint == "projects/122477/merge_requests/9":
+            assert method == "GET"
+            assert payload is None
+            return {"source_branch": "chore/sync-knots-api-master"}
+        if endpoint == "projects/122477/ci/lint":
+            assert method == "POST"
+            lint_payloads.append(payload)
+            return {"valid": True, "errors": [], "warnings": []}
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(gitlab_cli, "run_glab_api", fake_run_glab_api)
+
+    gitlab_cli.ci_lint(
+        path=ci_file,
+        cwd=tmp_path,
+        project="122477",
+        hostname=None,
+        dry_run=True,
+        include_jobs=False,
+        ref="refs/merge-requests/9/head",
+        source_branch=None,
+        show_merged_yaml=False,
+        as_json=True,
+    )
+
+    assert lint_payloads == [
+        {
+            "content": "test:\n  script: echo ok\n",
+            "dry_run": True,
+            "include_jobs": False,
+            "ref": "chore/sync-knots-api-master",
+        }
+    ]
+
+
+def test_ci_lint_uses_explicit_source_branch_for_merge_request_ref(
+    monkeypatch, tmp_path: Path
+) -> None:
+    ci_file = tmp_path / ".gitlab-ci.yml"
+    ci_file.write_text("test:\n  script: echo ok\n", encoding="utf-8")
+    lint_payloads: list[dict[str, object] | None] = []
+
+    def fake_run_glab_api(
+        *,
+        endpoint: str,
+        method: str,
+        payload: dict[str, object] | None,
+        cwd: Path,
+        hostname: str | None,
+    ) -> dict[str, object]:
+        assert method == "POST"
+        assert cwd == tmp_path
+        assert hostname is None
+
+        if endpoint == "projects/122477/ci/lint":
+            lint_payloads.append(payload)
+            return {"valid": True, "errors": [], "warnings": []}
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(gitlab_cli, "run_glab_api", fake_run_glab_api)
+
+    gitlab_cli.ci_lint(
+        path=ci_file,
+        cwd=tmp_path,
+        project="122477",
+        hostname=None,
+        dry_run=True,
+        include_jobs=False,
+        ref="refs/merge-requests/9/head",
+        source_branch="chore/sync-knots-api-master",
+        show_merged_yaml=False,
+        as_json=True,
+    )
+
+    assert lint_payloads == [
+        {
+            "content": "test:\n  script: echo ok\n",
+            "dry_run": True,
+            "include_jobs": False,
+            "ref": "chore/sync-knots-api-master",
+        }
+    ]


### PR DESCRIPTION
## Why

- 公司 GitLab 14.x 在 `ci/lint` dry-run 遇到 `refs/merge-requests/<iid>/head` 时可能因为缺少 `source_branch` 返回 500。
- 当前脚本需要把这个服务端兼容问题收敛掉，避免 agent 直接把 MR internal ref 发给 CI Lint。

## What

- 识别 `refs/merge-requests/<iid>/head` / `merge` 形式的 MR internal ref。
- 对 MR internal ref 的 dry-run 改用 source branch 调用 CI Lint；调用方可显式传 `--source-branch`，未传时脚本按 MR IID 查询 MR 元数据。
- 补充 gitlab-cli skill 文档和单元测试，覆盖自动解析与显式 source branch 两条路径。

BREAKING CHANGE: `ci lint --dry-run --ref refs/merge-requests/<iid>/head` 不再把 MR internal ref 原样提交给 CI Lint，而是改用 MR source branch。需要复现 GitLab 服务端对 raw MR internal ref 行为的调用方，应直接使用 `glab api` 构造原始请求。
