### PR TITLE
docs(change-request): 收紧 PR/MR Validation 写作规则

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ notification_method = "bel"
 | [`uv-cli-creator`](skills/uv-cli-creator/SKILL.md) | 为本仓库创建或修改 uv --script 风格的 Python CLI；当需要把重复命令封装成 `./scripts/...` 直接执行的工具时使用。 |
 | [`dcjanus-preferences`](skills/dcjanus-preferences/SKILL.md) | 记录 DCjanus 在不同语言中偏好的第三方库与使用场景，供 AI 在选型、引入依赖或替换库时优先参考。适用于 Python/Rust/Go 的库选择、技术方案对比、或需要遵循 DCjanus 个人偏好进行开发的场景。 |
 | [`fetch-url`](skills/fetch-url/SKILL.md) | 获取并提取链接正文（默认 Markdown）；内置 X/Twitter URL 处理，提升受限页面的抓取成功率。 |
-| [`change-request-writing`](skills/change-request-writing/SKILL.md) | 编写或更新 GitHub/GitLab Issue、PR、MR 的标题与正文；聚焦 final net diff、有效 Validation、Breaking Change 与避免本地路径泄露。 |
+| [`change-request-writing`](skills/change-request-writing/SKILL.md) | 编写或更新 GitHub/GitLab Issue、PR、MR 的标题与正文；聚焦 final net diff、Breaking Change、避免低价值验证噪声与本地路径泄露。 |
 | [`git-workflow`](skills/git-workflow/SKILL.md) | 处理 git 提交、推送、分支命名与提交信息规范；当任务涉及 commit、push、起分支或整理 commit message 时使用。 |
 | [`github-cli`](skills/github-cli/SKILL.md) | GitHub CLI 使用指引，面向 GitHub 资源交互（如 repo、issue、PR、comment、release、workflow） |
 | [`gitlab-cli`](skills/gitlab-cli/SKILL.md) | GitLab CLI（glab）使用指引，面向 GitLab 资源交互（如 project、issue、MR、comment、wiki） |

--- a/skills/change-request-writing/SKILL.md
+++ b/skills/change-request-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-request-writing
-description: 编写或更新 GitHub/GitLab Issue、PR、MR 的标题与正文；适用于创建、修改、重写 reviewer-facing 描述、Validation、Risks、Breaking Change、避免本地路径泄露等场景。
+description: 编写或更新 GitHub/GitLab Issue、PR、MR 的标题与正文；适用于创建、修改、重写 reviewer-facing 描述、Risks、Breaking Change、避免低价值验证噪声与本地路径泄露等场景。
 ---
 
 # Change Request Writing Skill
@@ -23,8 +23,11 @@ description: 编写或更新 GitHub/GitLab Issue、PR、MR 的标题与正文；
 - 先确认 base/head 或 target/source，再用 final net diff 作为正文依据：`git fetch` 后查看 `git diff --stat <base-or-target>...HEAD` 与 `git diff --name-status <base-or-target>...HEAD`；必要时再看关键文件 diff 或平台 diff。
 - 正文不要包含：中间提交顺序、调试过程、失败尝试、临时方案、merge/rebase/冲突解决过程、曾经实现过但最终 diff 已不存在的行为。
 - 正文不要包含本机绝对路径、home 目录、agent 工作区路径、临时正文文件路径或其它会暴露个人/机器环境的信息；如需引用仓库内文件，使用相对路径或 Markdown 链接。
-- `Validation` 默认可以省略；只有能增加 reviewer 信心的信息才写，例如真实端到端使用过目标场景、线上/页面/API/CLI 行为被实际确认，或修 BUG 时先构造稳定失败的回归 case 再修复到通过。
-- 不要把 CI、pipeline、workflow、job、格式化、lint、类型检查、普通单元测试、构建通过等常规卫生检查写进正文；这些通常属于合入门槛，信息增量低。也不要记录探索性失败、调试命令或临时注入失败，除非它是最终交付的已知风险。
+- PR/MR 正文默认不写 `Validation`。只有当验证内容提供 reviewer 在 diff 或平台 CI 状态里看不到的高信噪比行为证据时，才添加 `## Validation`。
+- 不要把 CI、pipeline、workflow、job、格式化、lint、类型检查、构建、普通单元测试、仓库标准测试命令或“测试通过”写进正文；这些属于合入门槛，平台已经展示，信息增量低。
+- 即使本地实际运行过 `go test ./...`、`cargo test`、`pnpm build`、`ruff check` 等命令，也不要为了证明“我测过了”而写入 PR/MR body；除非它是刻意构造的 red/green 回归验证，且 CI 不会自然覆盖这个信号。
+- 可写的 `Validation` 应聚焦 CI 看不到的结果：真实环境/线上/测试集群验证、手工 UI/API/CLI 行为确认、外部服务集成、迁移 dry-run、性能或兼容性数据、安全边界验证，或 bug 修复中的稳定复现用例从失败到通过。
+- 写 `Validation` 时描述“验证了什么行为和结果”，不要写命令流水账。不要记录探索性失败、调试命令或临时注入失败，除非它是最终交付的已知风险。
 - 更新已有 PR/MR 正文时，不要在旧正文上做局部补丁；先回读当前正文，再基于 final net diff 重写完整正文并替换过时内容。
 - 如果正文经历过实验性修改，最终更新前重新审视完整 PR/MR body，确保它只描述最终 diff；不要写 `rerun`、`after removing`、`now`、`previously` 这类暴露过程的措辞，除非过程本身是 reviewer 需要审查的证据。
 - Breaking change 按 final net diff / 对外行为判断，不按中间 commit 机械继承；只有最终净变化确实破坏既有用法时，才在标题和正文标识。
@@ -41,8 +44,9 @@ description: 编写或更新 GitHub/GitLab Issue、PR、MR 的标题与正文；
 
 1. 标题风格：英文、遵循语义化提交规范（如 `feat(scope): short summary`），简洁且描述核心目的；即使标题要求中文，语义化前缀仍需英文。
 2. 有 breaking change 时标题用 `type(scope)!: short summary`，正文加 `BREAKING CHANGE:` 说明影响和迁移方式；否则不要加 `!` 或 `BREAKING CHANGE:`。
-3. 描述风格：英文、短句和项目符号，优先让不看代码的读者快速理解动机、改动与必要验证，避免流水账与过多实现细节。涉及专有名词、函数名、方法名、类名、API 名称或配置键时，使用 inline code（反引号）包裹。
+3. 描述风格：英文、短句和项目符号，优先让不看代码的读者快速理解动机、改动与影响，避免流水账与过多实现细节。涉及专有名词、函数名、方法名、类名、API 名称或配置键时，使用 inline code（反引号）包裹。
 4. 默认正文格式：
    - `## Why`：1-2 条短句说明为什么要做这次改动，聚焦问题背景或目标。
    - `## What`：1-3 条说明主要变更，聚焦功能或行为层面的变化，不罗列琐碎实现细节。
-5. 可选正文块：仅在确有必要时再添加 `BREAKING CHANGE:`、`## Validation`、`## Risks` 或 `## Notes`。
+5. 默认不要添加 `## Validation`；仅在有 CI 看不到的高信噪比行为证据时添加，否则省略。
+6. 可选正文块：仅在确有必要时添加 `BREAKING CHANGE:`、`## Risks` 或 `## Notes`。


### PR DESCRIPTION
## Why

`change-request-writing` 目前虽然已经提示 Validation 可以省略，但 wording 仍容易让 agent 习惯性把 CI、lint、普通单元测试等低价值检查写进 PR/MR 描述。

这类信息通常已经由平台状态展示，放进正文反而会稀释 reviewer 真正需要看的净变化和风险。

## What

- 收紧 `change-request-writing` 的 Validation 规则：PR/MR 正文默认不写 `Validation`，只有 CI 看不到的高信噪比行为证据才写。
- 明确禁止把 CI 状态、pipeline/job、lint、build、普通单元测试、仓库标准测试命令或“测试通过”作为命令清单写入正文。
- 保留真正有价值的验证入口，例如真实环境验证、手工 UI/API/CLI 行为确认、外部集成、迁移 dry-run、性能/兼容性/安全边界数据，以及 bug 修复中的 red/green 回归证据。
- 同步 README 中 `change-request-writing` 的技能描述，强调避免低价值验证噪声。
