### PR TITLE
refactor(codex-session-reader): 改用官方 Python SDK

### DIFF
--- a/skills/codex-session-reader/README.md
+++ b/skills/codex-session-reader/README.md
@@ -6,13 +6,13 @@
 
 这个 skill 用来读取单个 Codex thread。
 
-实现上只支持 Codex，并通过 `codex app-server` 的官方 JSON-RPC 接口交互，不解析 `~/.codex` 下的 rollout JSONL 或 sqlite。当前范围也刻意收窄为只读，不提供 thread 写入、续写、fork 或归档能力；读取区间则通过 `--turns` 的 0-based 切片表达式控制。
+实现上只支持 Codex，并通过 Codex 官方 Python SDK 调用 app-server 的 `thread/read` 接口读取数据，不解析 `~/.codex` 下的 rollout JSONL 或 sqlite。当前范围也刻意收窄为只读，不提供 thread 写入、续写、fork 或归档能力；读取区间则通过 `--turns` 的 0-based 切片表达式控制。
 
 ## 来历
 
 这个 skill 的问题定义与使用体验明显受到 [Xuanwo/xurl](https://github.com/Xuanwo/xurl) 启发，尤其是“把 agent/thread 读取包装成一个可直接给 Codex 使用的能力”这一点。
 
-但当前实现没有复用 xurl 的 Rust 多 provider 架构，也没有沿用它的本地 session 解析逻辑；这里改为只支持 Codex，并通过 Codex 官方 `app-server` 的 `thread/list`、`thread/read` 等接口读取数据，以尽量降低对底层持久化格式的耦合。
+但当前实现没有复用 xurl 的 Rust 多 provider 架构，也没有沿用它的本地 session 解析逻辑；这里改为只支持 Codex，并通过 Codex 官方 SDK 读取 `thread/read` 返回的数据，以尽量降低对底层持久化格式的耦合。
 
 `xurl` 使用 Apache 2.0 许可：
 - [Xuanwo/xurl](https://github.com/Xuanwo/xurl)

--- a/skills/codex-session-reader/SKILL.md
+++ b/skills/codex-session-reader/SKILL.md
@@ -3,7 +3,7 @@ name: codex-session-reader
 description: 读取 Codex 的单个 session/thread；当已知 thread id 且需要查看或摘要会话内容时使用。
 ---
 
-只读查看单个 Codex session/thread 的 skill，底层通过 Codex 官方 Python SDK 调用 app-server 的 `thread/read` 接口读取。
+只读查看单个 Codex session/thread 的 skill。
 
 默认输出全部 turns；如只想看局部，可用 `--turns` 传 0-based、接近 Python 的切片表达式。
 
@@ -16,9 +16,7 @@ cd skills/codex-session-reader
 
 ## 环境注意事项
 
-- 这个 skill 通过 `openai-codex` Python SDK 读取本机 Codex session。
-- SDK 发布包会携带匹配的 Codex CLI runtime；通常不需要额外保证 `codex` 命令在当前 shell 的 `PATH` 中。
-- 如需强制使用本机某个特定 `codex` binary，应修改脚本里的 `CodexConfig` 并显式设置 `codex_bin`。
+- 脚本使用 `uv --script` 管理运行依赖。
 
 ## 何时使用
 
@@ -43,6 +41,6 @@ cd skills/codex-session-reader
 
 - 默认输出 `markdown`，适合继续交给 Codex 阅读或摘要。
 - 默认输出全部 turns。
-- `--format json` 输出 app-server 返回的结构化结果，便于脚本处理。
+- `--format json` 输出结构化结果，便于脚本处理。
 - 若发生区间裁剪，JSON 会额外包含 `truncated` 字段说明实际输出的是哪一段。
 - `--turns` 不支持 step；`1:10:2` 这类表达式会报错。

--- a/skills/codex-session-reader/SKILL.md
+++ b/skills/codex-session-reader/SKILL.md
@@ -3,7 +3,7 @@ name: codex-session-reader
 description: 读取 Codex 的单个 session/thread；当已知 thread id 且需要查看或摘要会话内容时使用。
 ---
 
-只读查看单个 Codex session/thread 的 skill，底层通过 `codex app-server` 官方接口读取。
+只读查看单个 Codex session/thread 的 skill，底层通过 Codex 官方 Python SDK 调用 app-server 的 `thread/read` 接口读取。
 
 默认输出全部 turns；如只想看局部，可用 `--turns` 传 0-based、接近 Python 的切片表达式。
 
@@ -16,18 +16,9 @@ cd skills/codex-session-reader
 
 ## 环境注意事项
 
-- 这个 skill 依赖本机可直接执行的 `codex` 命令，底层会调用 `codex app-server`。
-- 对当前 Codex 环境，工具执行不一定沿用交互式 `fish`，可能回退到 `zsh -lc`。
-- 所以只在 `fish` 里设置 `PNPM_HOME` 不够；必须让 `zsh` 启动时的 `PATH` 里也包含 `PNPM_HOME`，否则会报“未找到 `codex`”。
-- 推荐按 pnpm 官方风格在 zsh 配置里同时设置：
-
-```zsh
-export PNPM_HOME="$HOME/Library/pnpm"
-case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) export PATH="$PNPM_HOME:$PATH" ;;
-esac
-```
+- 这个 skill 通过 `openai-codex` Python SDK 读取本机 Codex session。
+- SDK 发布包会携带匹配的 Codex CLI runtime；通常不需要额外保证 `codex` 命令在当前 shell 的 `PATH` 中。
+- 如需强制使用本机某个特定 `codex` binary，应修改脚本里的 `CodexConfig` 并显式设置 `codex_bin`。
 
 ## 何时使用
 

--- a/skills/codex-session-reader/scripts/codex_session_reader.py
+++ b/skills/codex-session-reader/scripts/codex_session_reader.py
@@ -2,6 +2,7 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
+#     "openai-codex>=0.1.0b2",
 #     "pydantic>=2.12.5",
 #     "rich>=14.3.3",
 #     "typer>=0.24.1",
@@ -12,17 +13,15 @@
 
 from __future__ import annotations
 
-from collections import deque
 from datetime import UTC, datetime
 import json
-from queue import Empty, Queue
 import re
-import subprocess
 import sys
-import threading
-from time import monotonic
 from typing import Annotated, Any, Literal, TypeVar
 
+from openai_codex import CodexConfig
+from openai_codex.client import CodexClient
+from openai_codex.errors import CodexError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from rich.console import Console
 import typer
@@ -43,64 +42,6 @@ class AppModel(BaseModel):
         populate_by_name=True,
         extra="allow",
     )
-
-
-class ClientInfo(AppModel):
-    """初始化时声明的客户端信息。"""
-
-    name: str
-    title: str | None = None
-    version: str
-
-
-class InitializeCapabilities(AppModel):
-    """初始化能力声明。"""
-
-    experimental_api: bool = False
-    opt_out_notification_methods: list[str] | None = None
-
-
-class InitializeParams(AppModel):
-    """initialize 请求参数。"""
-
-    client_info: ClientInfo
-    capabilities: InitializeCapabilities | None = None
-
-
-class InitializeResponse(AppModel):
-    """initialize 响应。"""
-
-    user_agent: str
-
-
-class JsonRpcErrorPayload(AppModel):
-    """JSON-RPC 错误体。"""
-
-    code: int
-    message: str
-    data: Any | None = None
-
-
-class JsonRpcResponse(AppModel):
-    """JSON-RPC 响应。"""
-
-    id: int | str | None = None
-    result: Any | None = None
-    error: JsonRpcErrorPayload | None = None
-
-
-class JsonRpcNotification(AppModel):
-    """JSON-RPC 通知。"""
-
-    method: str
-    params: Any | None = None
-
-
-class ThreadReadParams(AppModel):
-    """thread/read 请求参数。"""
-
-    thread_id: str
-    include_turns: bool
 
 
 class ThreadStatus(AppModel):
@@ -189,11 +130,6 @@ class CodexSessionReaderError(RuntimeError):
     """skill 运行失败时的统一异常。"""
 
 
-APP_SERVER_SEND_ERROR = "向 app-server 发送请求失败。"
-APP_SERVER_INVALID_JSON_ERROR = "app-server 返回了非法 JSON。"
-APP_SERVER_TIMEOUT_ERROR = "等待 app-server 响应超时。"
-
-
 THREAD_ID_PATTERN = re.compile(
     r"^(?:urn:uuid:)?[0-9a-fA-F]{8}-"
     r"[0-9a-fA-F]{4}-"
@@ -203,7 +139,6 @@ THREAD_ID_PATTERN = re.compile(
 )
 
 AppModelType = TypeVar("AppModelType", bound=BaseModel)
-STDOUT_EOF = object()
 
 
 def validate_model_or_raise(
@@ -217,250 +152,28 @@ def validate_model_or_raise(
         raise CodexSessionReaderError(f"{label} 结构不合法。") from exc
 
 
-class CodexAppServerClient:
-    """`codex app-server` 的极薄同步 JSON-RPC client。"""
+def read_thread_via_sdk(thread_id: str, include_turns: bool) -> ThreadReadResponse:
+    """通过官方 Codex Python SDK 调用 `thread/read`。"""
 
-    def __init__(self, request_timeout: float = 30.0) -> None:
-        """初始化 client 配置。"""
+    config = CodexConfig(
+        client_name="codex-session-reader",
+        client_title="Codex Session Reader",
+        experimental_api=False,
+    )
+    try:
+        with CodexClient(config) as client:
+            client.initialize()
+            sdk_result = client.thread_read(thread_id, include_turns=include_turns)
+    except CodexError as exc:
+        raise CodexSessionReaderError(f"Codex SDK 调用失败：{exc}") from exc
+    except OSError as exc:
+        reason = exc.strerror or str(exc)
+        raise CodexSessionReaderError(
+            f"无法启动 Codex SDK app-server：{reason}"
+        ) from exc
 
-        self.request_timeout = request_timeout
-        self._process: subprocess.Popen[str] | None = None
-        self._next_id = 1
-        self._stderr_lines: deque[str] = deque(maxlen=200)
-        self._stdout_queue: Queue[str | object] = Queue()
-        self._stdout_thread: threading.Thread | None = None
-        self._stderr_thread: threading.Thread | None = None
-
-    def __enter__(self) -> "CodexAppServerClient":
-        """启动 app-server 子进程并完成握手。"""
-
-        try:
-            process = subprocess.Popen(
-                ["codex", "app-server"],
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                encoding="utf-8",
-                bufsize=1,
-            )
-        except OSError as exc:
-            if isinstance(exc, FileNotFoundError):
-                message = "未找到 `codex`，无法启动 `codex app-server`。"
-            else:
-                reason = exc.strerror or str(exc)
-                message = f"无法启动 `codex app-server` ({reason})。"
-            raise CodexSessionReaderError(message) from exc
-
-        self._process = process
-        self._stderr_lines.clear()
-        self._stdout_queue = Queue()
-        self._stdout_thread = threading.Thread(
-            target=self._drain_stdout,
-            name="codex-session-reader-stdout",
-            daemon=True,
-        )
-        self._stderr_thread = threading.Thread(
-            target=self._drain_stderr,
-            name="codex-session-reader-stderr",
-            daemon=True,
-        )
-        self._stdout_thread.start()
-        self._stderr_thread.start()
-        try:
-            self.initialize()
-        except BaseException:
-            self.__exit__(None, None, None)
-            raise
-        return self
-
-    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
-        """关闭 app-server 子进程。"""
-
-        if self._process is None:
-            return
-
-        process = self._process
-        try:
-            if process.stdin:
-                process.stdin.close()
-            if process.poll() is None:
-                process.terminate()
-                try:
-                    process.wait(timeout=3)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=3)
-        finally:
-            if process.stdout:
-                process.stdout.close()
-            if process.stderr:
-                process.stderr.close()
-            self._process = None
-
-    def _drain_stderr(self) -> None:
-        """持续读取 stderr，避免阻塞并保留最近日志。"""
-
-        if self._process is None or self._process.stderr is None:
-            return
-
-        for line in self._process.stderr:
-            self._stderr_lines.append(line.rstrip("\n"))
-
-    def _drain_stdout(self) -> None:
-        """持续读取 stdout，并转交给主线程消费。"""
-
-        if self._process is None or self._process.stdout is None:
-            return
-
-        for line in self._process.stdout:
-            self._stdout_queue.put(line)
-        self._stdout_queue.put(STDOUT_EOF)
-
-    def _stderr_tail(self) -> str:
-        """返回最近的 stderr 摘要。"""
-
-        if not self._stderr_lines:
-            return ""
-        return "\n".join(self._stderr_lines)
-
-    def _ensure_running(self) -> subprocess.Popen[str]:
-        """确保子进程可用。"""
-
-        if self._process is None:
-            raise CodexSessionReaderError("app-server 尚未启动。")
-        return self._process
-
-    def _send_json(self, payload: dict[str, Any]) -> None:
-        """发送一条 JSON-RPC 消息。"""
-
-        process = self._ensure_running()
-        if process.stdin is None:
-            raise CodexSessionReaderError("app-server stdin 不可用。")
-
-        try:
-            process.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
-            process.stdin.flush()
-        except OSError as exc:
-            message = APP_SERVER_SEND_ERROR
-            if detail := self._stderr_tail():
-                message += f"\nstderr:\n{detail}"
-            raise CodexSessionReaderError(message) from exc
-
-    def _read_message(
-        self, deadline: float | None = None
-    ) -> JsonRpcResponse | JsonRpcNotification:
-        """读取一条来自 app-server 的 JSON-RPC 消息。"""
-
-        process = self._ensure_running()
-        if deadline is not None:
-            timeout = deadline - monotonic()
-            if timeout <= 0:
-                raise CodexSessionReaderError(APP_SERVER_TIMEOUT_ERROR)
-        else:
-            timeout = None
-
-        try:
-            line = self._stdout_queue.get(timeout=timeout)
-        except Empty as exc:
-            raise CodexSessionReaderError(APP_SERVER_TIMEOUT_ERROR) from exc
-
-        if line is STDOUT_EOF:
-            line = ""
-        if not isinstance(line, str):
-            raise CodexSessionReaderError("app-server stdout 返回了未知消息。")
-
-        if line:
-            try:
-                payload = json.loads(line)
-            except json.JSONDecodeError as exc:
-                message = f"{APP_SERVER_INVALID_JSON_ERROR} {line.strip()}"
-                if detail := self._stderr_tail():
-                    message += f"\nstderr:\n{detail}"
-                raise CodexSessionReaderError(message) from exc
-            if not isinstance(payload, dict):
-                message = f"{APP_SERVER_INVALID_JSON_ERROR} 顶层必须是对象。"
-                if detail := self._stderr_tail():
-                    message += f"\nstderr:\n{detail}"
-                raise CodexSessionReaderError(message)
-            if "method" in payload:
-                return validate_model_or_raise(
-                    JsonRpcNotification, payload, "app-server 通知"
-                )
-            return validate_model_or_raise(JsonRpcResponse, payload, "app-server 响应")
-
-        return_code = process.poll()
-        stderr_tail = self._stderr_tail()
-        message = "app-server 已提前退出。"
-        if return_code is not None:
-            message += f" exit_code={return_code}"
-        if stderr_tail:
-            message += f"\nstderr:\n{stderr_tail}"
-        raise CodexSessionReaderError(message)
-
-    def initialize(self) -> InitializeResponse:
-        """执行 initialize / initialized 握手。"""
-
-        response = self.request(
-            "initialize",
-            InitializeParams(
-                client_info=ClientInfo(
-                    name="codex-session-reader",
-                    title="Codex Session Reader",
-                    version="0.1.0",
-                ),
-                capabilities=InitializeCapabilities(experimental_api=False),
-            ),
-        )
-        self.notify("initialized", None)
-        return validate_model_or_raise(InitializeResponse, response, "initialize 响应")
-
-    def notify(
-        self, method: str, params: AppModel | dict[str, Any] | None
-    ) -> None:
-        """发送 JSON-RPC 通知。"""
-
-        payload: dict[str, Any] = {"method": method}
-        if params is not None:
-            if isinstance(params, AppModel):
-                payload["params"] = params.model_dump(by_alias=True, exclude_none=True)
-            else:
-                payload["params"] = params
-        self._send_json(payload)
-
-    def request(self, method: str, params: AppModel | dict[str, Any] | None) -> Any:
-        """发送 JSON-RPC 请求并等待对应响应。"""
-
-        request_id = self._next_id
-        self._next_id += 1
-        deadline = monotonic() + self.request_timeout
-
-        payload: dict[str, Any] = {"id": request_id, "method": method}
-        if params is not None:
-            if isinstance(params, AppModel):
-                payload["params"] = params.model_dump(by_alias=True, exclude_none=True)
-            else:
-                payload["params"] = params
-        self._send_json(payload)
-
-        while True:
-            message = self._read_message(deadline=deadline)
-            if isinstance(message, JsonRpcNotification):
-                continue
-            if message.id != request_id:
-                continue
-            if message.error is not None:
-                detail = f"{message.error.code}: {message.error.message}"
-                if message.error.data is not None:
-                    detail += f"\n{json.dumps(message.error.data, ensure_ascii=False, indent=2)}"
-                raise CodexSessionReaderError(detail)
-            return message.result
-
-    def read_thread(self, params: ThreadReadParams) -> ThreadReadResponse:
-        """调用 `thread/read`。"""
-
-        result = self.request("thread/read", params)
-        return validate_model_or_raise(ThreadReadResponse, result, "thread/read 响应")
+    payload = sdk_result.model_dump(by_alias=True, mode="json")
+    return validate_model_or_raise(ThreadReadResponse, payload, "thread/read 响应")
 
 
 def unix_ts_to_text(value: int) -> str:
@@ -766,13 +479,7 @@ def read_thread_command(
 
     normalized_thread_id = validate_thread_id(thread_id)
 
-    with CodexAppServerClient() as client:
-        result = client.read_thread(
-            ThreadReadParams(
-                thread_id=normalized_thread_id,
-                include_turns=include_turns,
-            )
-        )
+    result = read_thread_via_sdk(normalized_thread_id, include_turns=include_turns)
 
     if format_name == "json":
         selected_turns, selected_start, selected_end = select_turns_by_expr(


### PR DESCRIPTION
## Why

- Codex 官方 Python SDK 已经覆盖本 skill 需要的 app-server `thread/read` 能力。
- 继续维护自写 JSON-RPC transport 会增加不必要的协议、进程生命周期和错误处理成本。

## What

- 将 `codex-session-reader` 的读取链路改为通过 `openai-codex` SDK 调用 `CodexClient.thread_read`。
- 保留现有 CLI、Markdown/JSON 输出、`--preview-only` 和 `--turns` 裁剪行为。
- 更新 skill 文档，移除对 shell `PATH` 中必须存在 `codex` 的旧说明。

## Notes

- 这不是 breaking change；用户侧命令和输出格式保持不变。
