### PR TITLE
chore: 升级 uv script 依赖下限

### DIFF
--- a/scripts/codex_usage.py
+++ b/scripts/codex_usage.py
@@ -5,7 +5,7 @@
 # dependencies = [
 #     "pydantic>=2.13.4",
 #     "rich>=15.0.0",
-#     "typer>=0.25.1",
+#     "typer>=0.26.7",
 # ]
 # ///
 

--- a/scripts/install_codex_cli.py
+++ b/scripts/install_codex_cli.py
@@ -4,7 +4,7 @@
 # dependencies = [
 #     "pydantic>=2.13.4",
 #     "rich>=15.0.0",
-#     "typer>=0.26.5",
+#     "typer>=0.26.7",
 #     "zstandard>=0.25.0",
 # ]
 # ///

--- a/scripts/token_count.py
+++ b/scripts/token_count.py
@@ -3,10 +3,10 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "pydantic>=2.12.5",
-#     "rich>=14.2.0",
-#     "tiktoken>=0.12.0",
-#     "typer>=0.20.0",
+#     "pydantic>=2.13.4",
+#     "rich>=15.0.0",
+#     "tiktoken>=0.13.0",
+#     "typer>=0.26.7",
 # ]
 # ///
 
@@ -59,7 +59,11 @@ def main(
         raise typer.Exit(code=1)
 
     try:
-        text = spec.file_path.read_text(encoding="utf-8") if spec.file_path else sys.stdin.read()
+        text = (
+            spec.file_path.read_text(encoding="utf-8")
+            if spec.file_path
+            else sys.stdin.read()
+        )
     except OSError as exc:  # noqa: PERF203 - keep clarity
         console.print(f"[red]读取输入失败：{exc}[/red]")
         raise typer.Exit(code=1)

--- a/scripts/token_tree.py
+++ b/scripts/token_tree.py
@@ -3,10 +3,10 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "pydantic>=2.12.5",
-#     "rich>=14.2.0",
-#     "tiktoken>=0.12.0",
-#     "typer>=0.20.0",
+#     "pydantic>=2.13.4",
+#     "rich>=15.0.0",
+#     "tiktoken>=0.13.0",
+#     "typer>=0.26.7",
 #     # 交互式 TUI 暂不启用，若需可添加 textual>=6.10.0
 # ]
 # ///
@@ -30,7 +30,8 @@ app = typer.Typer(add_completion=False, no_args_is_help=False)
 
 class InputSpec(BaseModel):
     repo_path: Path | None = Field(
-        default=None, description="Git 仓库路径，默认自动探测为当前工作目录所属仓库根目录"
+        default=None,
+        description="Git 仓库路径，默认自动探测为当前工作目录所属仓库根目录",
     )
 
     @field_validator("repo_path")
@@ -248,7 +249,9 @@ def summarize_tree(node: TokenNode) -> tuple[int, int, str]:
     return count, max_tokens, max_name
 
 
-@app.command(help="统计仓库内 AGENTS.md 与 skills/**/SKILL.md 的 token 数，并以树状图展示。")
+@app.command(
+    help="统计仓库内 AGENTS.md 与 skills/**/SKILL.md 的 token 数，并以树状图展示。"
+)
 def main(
     path: Path | None = typer.Option(
         None, "--path", "-p", help="Git 仓库路径，默认自动探测"

--- a/skills/codex-session-reader/scripts/codex_session_reader.py
+++ b/skills/codex-session-reader/scripts/codex_session_reader.py
@@ -2,11 +2,13 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "openai-codex>=0.1.0b2",
-#     "pydantic>=2.12.5",
-#     "rich>=14.3.3",
-#     "typer>=0.24.1",
+#     "openai-codex>=0.1.0b3",
+#     "pydantic>=2.13.4",
+#     "rich>=15.0.0",
+#     "typer>=0.26.7",
 # ]
+# [tool.uv]
+# prerelease = "allow"
 # ///
 
 """读取 Codex session/thread 的只读 CLI。"""

--- a/skills/codex-thread-namer/scripts/set_current_thread_name.py
+++ b/skills/codex-thread-namer/scripts/set_current_thread_name.py
@@ -2,8 +2,10 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "openai-codex>=0.1.0b2",
+#     "openai-codex>=0.1.0b3",
 # ]
+# [tool.uv]
+# prerelease = "allow"
 # ///
 
 """Set the current Codex thread name through the Codex Python SDK."""

--- a/skills/confluence-cli/scripts/confluence_cli.py
+++ b/skills/confluence-cli/scripts/confluence_cli.py
@@ -2,11 +2,11 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "httpxyz>=0.28.2",
-#     "markdown-it-py>=4.0.0",
-#     "pydantic>=2.12.5",
-#     "rich>=14.1.0",
-#     "typer>=0.17.4",
+#     "httpxyz>=0.31.2",
+#     "markdown-it-py>=4.2.0",
+#     "pydantic>=2.13.4",
+#     "rich>=15.0.0",
+#     "typer>=0.26.7",
 # ]
 # ///
 """Confluence CLI 工具入口。"""

--- a/skills/fetch-url/scripts/fetch_url.py
+++ b/skills/fetch-url/scripts/fetch_url.py
@@ -3,10 +3,10 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "playwright>=1.49.0",
-#     "rich>=14.2.0",
-#     "trafilatura>=2.0.0",
-#     "typer>=0.20.1",
+#     "playwright>=1.60.0",
+#     "rich>=15.0.0",
+#     "trafilatura>=2.1.0",
+#     "typer>=0.26.7",
 # ]
 # ///
 
@@ -33,7 +33,9 @@ import trafilatura
 APP = typer.Typer(add_completion=False)
 CONSOLE = Console()
 
-OutputFormat = Literal["csv", "html", "json", "markdown", "raw-html", "txt", "xml", "xmltei"]
+OutputFormat = Literal[
+    "csv", "html", "json", "markdown", "raw-html", "txt", "xml", "xmltei"
+]
 FetchStrategy = Literal["auto", "agent", "jina", "browser"]
 TWITTER_HOSTS = {
     "x.com",
@@ -114,7 +116,9 @@ def render_html(
                     highlight=False,
                 )
         elif verbose:
-            CONSOLE.print("[cyan]Using Playwright-managed Chromium[/cyan]", highlight=False)
+            CONSOLE.print(
+                "[cyan]Using Playwright-managed Chromium[/cyan]", highlight=False
+            )
 
         browser = playwright.chromium.launch(**launch_options)
         context = browser.new_context()
@@ -128,7 +132,10 @@ def render_html(
                 CONSOLE.print("[cyan]Load event reached[/cyan]", highlight=False)
         except PlaywrightTimeoutError:
             if verbose:
-                CONSOLE.print("[yellow]Load event wait timed out, continue[/yellow]", highlight=False)
+                CONSOLE.print(
+                    "[yellow]Load event wait timed out, continue[/yellow]",
+                    highlight=False,
+                )
 
         # Wait briefly for client-side rendering to settle without risking long hangs.
         deadline = monotonic() + 2.0
@@ -153,15 +160,21 @@ def render_html(
         browser.close()
 
     if verbose:
-        CONSOLE.print(f"[green]Rendered HTML size[/green] {len(html)} chars", highlight=False)
+        CONSOLE.print(
+            f"[green]Rendered HTML size[/green] {len(html)} chars", highlight=False
+        )
 
     return html
 
 
-def extract_content(html: str, url: str, output_format: OutputFormat, verbose: bool) -> str:
+def extract_content(
+    html: str, url: str, output_format: OutputFormat, verbose: bool
+) -> str:
     """使用 trafilatura 从 HTML 提取内容。"""
     if verbose:
-        CONSOLE.print(f"[cyan]Extracting content[/cyan] as {output_format}", highlight=False)
+        CONSOLE.print(
+            f"[cyan]Extracting content[/cyan] as {output_format}", highlight=False
+        )
 
     content = trafilatura.extract(
         html,
@@ -174,7 +187,10 @@ def extract_content(html: str, url: str, output_format: OutputFormat, verbose: b
         raise ValueError("Failed to extract main content from the rendered HTML.")
 
     if verbose:
-        CONSOLE.print(f"[green]Extracted content size[/green] {len(content)} chars", highlight=False)
+        CONSOLE.print(
+            f"[green]Extracted content size[/green] {len(content)} chars",
+            highlight=False,
+        )
 
     return content
 
@@ -183,7 +199,9 @@ def fetch_agent_markdown(url: str, timeout_ms: int, verbose: bool) -> str | None
     """通过 Accept 协商优先请求 text/markdown，命中则直接返回。"""
 
     if verbose:
-        CONSOLE.print("[cyan]Trying Markdown for Agents negotiation[/cyan]", highlight=False)
+        CONSOLE.print(
+            "[cyan]Trying Markdown for Agents negotiation[/cyan]", highlight=False
+        )
 
     request = Request(  # noqa: S310 - 本地 CLI 可信输入, URL 由用户主动提供
         url,
@@ -276,7 +294,9 @@ def is_obvious_jina_block_page(content: str) -> bool:
     """识别少数非常明显的 Jina 限流或挑战页。"""
 
     snippet = content[:4000].lower()
-    return any(all(part in snippet for part in signal) for signal in JINA_BLOCK_PAGE_SIGNALS)
+    return any(
+        all(part in snippet for part in signal) for signal in JINA_BLOCK_PAGE_SIGNALS
+    )
 
 
 def extract_twitter_status_id(url: str) -> str | None:
@@ -299,7 +319,9 @@ def extract_twitter_status_id(url: str) -> str | None:
     return None
 
 
-def fetch_fxtwitter_status(status_id: str, timeout_ms: int, verbose: bool) -> dict[str, Any] | None:
+def fetch_fxtwitter_status(
+    status_id: str, timeout_ms: int, verbose: bool
+) -> dict[str, Any] | None:
     """调用 FxTwitter API 获取结构化推文数据。"""
 
     api_url = f"{FXTWITTER_API_ROOT}/{status_id}"
@@ -336,7 +358,9 @@ def fetch_fxtwitter_status(status_id: str, timeout_ms: int, verbose: bool) -> di
     return payload
 
 
-def _extract_thread_entries(payload: dict[str, Any], root_status_id: str) -> list[dict[str, Any]]:
+def _extract_thread_entries(
+    payload: dict[str, Any], root_status_id: str
+) -> list[dict[str, Any]]:
     """从 FxTwitter payload 中提取 thread 条目并去重。"""
 
     thread = payload.get("thread")
@@ -354,7 +378,9 @@ def _extract_thread_entries(payload: dict[str, Any], root_status_id: str) -> lis
                 raw_entries.append(status_value)
             else:
                 # Best effort fallback: some payloads may store id->status dictionaries.
-                dict_values = [value for value in thread.values() if isinstance(value, dict)]
+                dict_values = [
+                    value for value in thread.values() if isinstance(value, dict)
+                ]
                 raw_entries.extend(dict_values)
 
     entries: list[dict[str, Any]] = []
@@ -476,7 +502,9 @@ def render_fxtwitter_markdown(payload: dict[str, Any], source_url: str) -> str:
                 if not isinstance(item, dict):
                     continue
                 media_type = str(item.get("type") or "media")
-                media_url = str(item.get("url") or item.get("thumbnail_url") or "").strip()
+                media_url = str(
+                    item.get("url") or item.get("thumbnail_url") or ""
+                ).strip()
                 if media_url:
                     lines.append(f"- {media_type}: {media_url}")
 
@@ -492,8 +520,12 @@ def render_fxtwitter_markdown(payload: dict[str, Any], source_url: str) -> str:
 @APP.command()
 def fetch(
     url: str = typer.Argument(..., help="Target URL to render into content."),
-    output: Path | None = typer.Option(None, help="Write output to file instead of stdout."),
-    timeout_ms: int = typer.Option(60000, help="Playwright navigation timeout in milliseconds."),
+    output: Path | None = typer.Option(
+        None, help="Write output to file instead of stdout."
+    ),
+    timeout_ms: int = typer.Option(
+        60000, help="Playwright navigation timeout in milliseconds."
+    ),
     browser_path: Path | None = typer.Option(
         None,
         help="Optional local Chromium-based browser path. Auto-detected if omitted.",
@@ -506,14 +538,18 @@ def fetch(
         "auto",
         help="Fetch strategy for markdown: auto, agent, jina, browser.",
     ),
-    verbose: bool = typer.Option(False, "--verbose", help="Print progress and diagnostic logs."),
+    verbose: bool = typer.Option(
+        False, "--verbose", help="Print progress and diagnostic logs."
+    ),
 ) -> None:
     """通过 Playwright 渲染并用 trafilatura 提取内容。"""
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"}:
         raise typer.BadParameter("Only http or https URLs are supported.")
     if output_format != "markdown" and fetch_strategy != "auto":
-        raise typer.BadParameter("Custom fetch strategy is only supported with markdown output.")
+        raise typer.BadParameter(
+            "Custom fetch strategy is only supported with markdown output."
+        )
 
     resolved_browser_path = str(browser_path) if browser_path else detect_browser_path()
     try:
@@ -533,11 +569,16 @@ def fetch(
                     )
                 content = render_fxtwitter_markdown(payload, source_url=url)
                 if verbose:
-                    CONSOLE.print("[green]Using FxTwitter API markdown path[/green]", highlight=False)
+                    CONSOLE.print(
+                        "[green]Using FxTwitter API markdown path[/green]",
+                        highlight=False,
+                    )
         if output_format == "markdown":
             if content is None:
                 if fetch_strategy == "auto":
-                    content = fetch_agent_markdown(url, timeout_ms=timeout_ms, verbose=verbose)
+                    content = fetch_agent_markdown(
+                        url, timeout_ms=timeout_ms, verbose=verbose
+                    )
                     if content is None:
                         content = fetch_jina_reader_markdown(
                             url,
@@ -545,14 +586,18 @@ def fetch(
                             verbose=verbose,
                         )
                 elif fetch_strategy == "agent":
-                    content = fetch_agent_markdown(url, timeout_ms=timeout_ms, verbose=verbose)
+                    content = fetch_agent_markdown(
+                        url, timeout_ms=timeout_ms, verbose=verbose
+                    )
                     if content is None:
                         raise ValueError(
                             "Markdown negotiation did not return usable content. "
                             "Try --fetch-strategy jina or --fetch-strategy browser."
                         )
                 elif fetch_strategy == "jina":
-                    content = fetch_jina_reader_markdown(url, timeout_ms=timeout_ms, verbose=verbose)
+                    content = fetch_jina_reader_markdown(
+                        url, timeout_ms=timeout_ms, verbose=verbose
+                    )
                     if content is None:
                         raise ValueError(
                             "Jina Reader did not return usable content. "
@@ -560,7 +605,10 @@ def fetch(
                             "--fetch-strategy browser."
                         )
                 elif fetch_strategy == "browser" and verbose:
-                    CONSOLE.print("[cyan]Skipping non-browser markdown readers[/cyan]", highlight=False)
+                    CONSOLE.print(
+                        "[cyan]Skipping non-browser markdown readers[/cyan]",
+                        highlight=False,
+                    )
         if content is None:
             html = render_html(
                 url,

--- a/skills/git-workflow/scripts/codex_git_commit.py
+++ b/skills/git-workflow/scripts/codex_git_commit.py
@@ -2,9 +2,11 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "openai-codex>=0.1.0b2",
-#     "typer>=0.24.1",
+#     "openai-codex>=0.1.0b3",
+#     "typer>=0.26.7",
 # ]
+# [tool.uv]
+# prerelease = "allow"
 # ///
 
 """解析当前 Codex shell 环境对应的 agent/model 信息并输出 JSON。"""

--- a/skills/github-cli/scripts/configure_squash_merge_policy.py
+++ b/skills/github-cli/scripts/configure_squash_merge_policy.py
@@ -2,8 +2,8 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "rich>=14.2.0",
-#     "typer>=0.20.0",
+#     "rich>=15.0.0",
+#     "typer>=0.26.7",
 # ]
 # ///
 

--- a/skills/gitlab-cli/scripts/configure_squash_merge_policy.py
+++ b/skills/gitlab-cli/scripts/configure_squash_merge_policy.py
@@ -2,8 +2,8 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "rich>=14.2.0",
-#     "typer>=0.20.0",
+#     "rich>=15.0.0",
+#     "typer>=0.26.7",
 # ]
 # ///
 

--- a/skills/gitlab-cli/scripts/gitlab_cli.py
+++ b/skills/gitlab-cli/scripts/gitlab_cli.py
@@ -2,8 +2,8 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "rich>=14.2.0",
-#     "typer>=0.20.0",
+#     "rich>=15.0.0",
+#     "typer>=0.26.7",
 # ]
 # ///
 

--- a/skills/google-sheets-cli/scripts/gsheets_cli.py
+++ b/skills/google-sheets-cli/scripts/gsheets_cli.py
@@ -2,11 +2,11 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "google-api-python-client>=2.187.0",
-#     "google-auth-httplib2>=0.2.1",
-#     "google-auth-oauthlib>=1.2.2",
-#     "rich>=14.2.0",
-#     "typer>=0.20.1",
+#     "google-api-python-client>=2.197.0",
+#     "google-auth-httplib2>=0.4.0",
+#     "google-auth-oauthlib>=1.4.0",
+#     "rich>=15.0.0",
+#     "typer>=0.26.7",
 # ]
 # ///
 """Google Sheets CLI for Codex skills."""

--- a/skills/ticktick-cli/scripts/ticktick_cli.py
+++ b/skills/ticktick-cli/scripts/ticktick_cli.py
@@ -2,10 +2,10 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "httpxyz>=0.28.2",
-#     "typer>=0.20.1",
-#     "pydantic>=2.12.5",
-#     "rich>=14.2.0",
+#     "httpxyz>=0.31.2",
+#     "typer>=0.26.7",
+#     "pydantic>=2.13.4",
+#     "rich>=15.0.0",
 # ]
 # ///
 


### PR DESCRIPTION
## 为什么

- 上一个 PR 已经能扫描 uv script 依赖下限，现在这次把扫描出的过时声明直接升级掉。
- 仓库里的脚本场景比较简单，统一提升 direct dependency 下限可以减少后续维护噪声。

## 改了什么

- 将仓库内 PEP 723 / uv script 的 direct dependency 下限统一提升到当前 PyPI 最新版本。
- 统一 `pydantic`、`rich`、`typer` 等多个脚本之间不一致的依赖声明。
- 对使用 `openai-codex>=0.1.0b3` 的脚本补充 `tool.uv.prerelease = "allow"`，保证其传递预发布依赖能在直接运行脚本时被 uv 解析。

## 影响

- 这次只调整脚本内依赖声明，不引入 lockfile。
- 依赖扫描结果已清空需要关注项。
