### PR TITLE
[codex] 为 Codex 安装脚本同步安装 shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ notification_method = "bel"
   - [`token_count.py`](scripts/token_count.py)：基于 [tiktoken](https://github.com/openai/tiktoken) 的 token 计数 CLI
   - [`token_tree.py`](scripts/token_tree.py)：统计仓库内所有 Git 跟踪文本文件的 token 数，按树状结构输出；支持全局比例进度条、对齐条形显示与百分比，可用 `--bar-width` 调整条形宽度
   - [`codex_usage.py`](scripts/codex_usage.py)：统计 Codex JSONL session 的 token 用量和预估价格，默认同时读取 `~/.codex/sessions` 与 `~/.codex/archived_sessions`，价格信息缓存到 XDG cache 且最多复用 7 天
-  - [`install_codex_cli.py`](scripts/install_codex_cli.py)：从 [openai/codex](https://github.com/openai/codex/releases) 最新 release 下载当前平台的 Codex CLI 预编译 binary，安装到用户级 XDG binary 目录，并在可跳过下载时复用本地状态
+  - [`install_codex_cli.py`](scripts/install_codex_cli.py)：从 [openai/codex](https://github.com/openai/codex/releases) 最新 release 下载当前平台的 Codex CLI 预编译 binary，安装到用户级 XDG binary 目录，并为当前 shell 同步安装 Codex completion；可用 `--completion-shell fish` 显式指定目标 shell，可跳过下载时复用本地状态
   - [`check_script_deps.py`](scripts/check_script_deps.py)：扫描仓库内 PEP 723 / uv script 依赖声明，对比 PyPI 最新版本，并在定时 GitHub Action 中输出依赖下限落后或声明不一致的报告
 
 ### 技能列表

--- a/scripts/install_codex_cli.py
+++ b/scripts/install_codex_cli.py
@@ -51,6 +51,8 @@ console = Console()
 app = typer.Typer(add_completion=False, no_args_is_help=False)
 
 ArchiveKind = Literal["zst", "tar.zst", "tar.gz", "zip", "direct"]
+CompletionShell = Literal["bash", "elvish", "fish", "powershell", "zsh"]
+CompletionStatus = Literal["installed", "updated", "unchanged", "skipped"]
 StateStatus = Literal["match", "missing", "stale"]
 VERSION_PATTERN = re.compile(
     r"(?<![0-9A-Za-z])"
@@ -78,6 +80,7 @@ class Release(BaseModel):
 
 class InstallSpec(BaseModel):
     install_dir: Path | None = Field(default=None)
+    completion_shell: CompletionShell | None = Field(default=None)
 
     @field_validator("install_dir")
     @classmethod
@@ -85,6 +88,13 @@ class InstallSpec(BaseModel):
         if value is None:
             return value
         return value.expanduser()
+
+    @field_validator("completion_shell", mode="before")
+    @classmethod
+    def normalize_completion_shell(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return value.lower()
 
 
 @dataclass(frozen=True)
@@ -115,12 +125,27 @@ class InstallResult:
     path_warning: str | None
     status: Literal["installed", "updated", "unchanged"]
     downloaded: bool
+    completion: "CompletionInstallResult"
 
 
 @dataclass(frozen=True)
 class ReleaseSelection:
     release: Release
     candidates_count: int
+
+
+@dataclass(frozen=True)
+class CompletionTarget:
+    shell: CompletionShell
+    path: Path
+
+
+@dataclass(frozen=True)
+class CompletionInstallResult:
+    shell: CompletionShell | None
+    path: Path | None
+    status: CompletionStatus
+    warning: str | None = None
 
 
 class InstallState(BaseModel):
@@ -148,6 +173,16 @@ def xdg_state_file() -> Path:
         else Path.home() / ".local" / "state"
     )
     return base / "prompts" / "install_codex_cli.json"
+
+
+def xdg_config_home() -> Path:
+    raw = os.environ.get("XDG_CONFIG_HOME")
+    return Path(raw).expanduser() if raw else Path.home() / ".config"
+
+
+def xdg_data_home() -> Path:
+    raw = os.environ.get("XDG_DATA_HOME")
+    return Path(raw).expanduser() if raw else Path.home() / ".local" / "share"
 
 
 def current_platform_target() -> PlatformTarget:
@@ -425,6 +460,151 @@ def install_executable(
     return status
 
 
+def write_text_atomic(path: Path, content: str) -> CompletionStatus:
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return "unchanged"
+
+    status: CompletionStatus = "updated" if path.exists() else "installed"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        mode="w",
+        encoding="utf-8",
+        delete=False,
+    ) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+        tmp_file.write(content)
+    os.replace(tmp_path, path)
+    return status
+
+
+def detect_completion_shell() -> CompletionShell | None:
+    shell_path = os.environ.get("SHELL")
+    if shell_path:
+        shell_name = Path(shell_path).name.lower()
+        if shell_name in {"bash", "fish", "zsh", "elvish"}:
+            return shell_name
+        if shell_name in {"pwsh", "powershell", "powershell.exe", "pwsh.exe"}:
+            return "powershell"
+
+    if platform.system().lower() == "windows":
+        return "powershell"
+    return None
+
+
+def zsh_fpath_dirs() -> list[Path]:
+    zsh = shutil.which("zsh")
+    if zsh is None:
+        return []
+    try:
+        result = subprocess.run(
+            [zsh, "-lc", "print -r -- $fpath"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return []
+    return [Path(raw).expanduser() for raw in result.stdout.split() if raw]
+
+
+def writable_zsh_completion_dir() -> Path | None:
+    home = Path.home()
+    for directory in zsh_fpath_dirs():
+        try:
+            resolved = directory.expanduser().resolve()
+        except OSError:
+            continue
+        if not directory.exists() or not directory.is_dir():
+            continue
+        if not same_path_or_child(resolved, home):
+            continue
+        if os.access(directory, os.W_OK):
+            return directory
+    return None
+
+
+def same_path_or_child(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent.expanduser().resolve())
+    except ValueError:
+        return False
+    except OSError:
+        return False
+    return True
+
+
+def completion_target_for_shell(shell: CompletionShell) -> CompletionTarget | None:
+    if shell == "fish":
+        return CompletionTarget(
+            shell, xdg_config_home() / "fish" / "completions" / "codex.fish"
+        )
+    if shell == "bash":
+        return CompletionTarget(
+            shell, xdg_data_home() / "bash-completion" / "completions" / "codex.bash"
+        )
+    if shell == "zsh":
+        directory = writable_zsh_completion_dir()
+        if directory is None:
+            return None
+        return CompletionTarget(shell, directory / "_codex")
+    if shell == "elvish":
+        return CompletionTarget(
+            shell, xdg_config_home() / "elvish" / "lib" / "codex-completion.elv"
+        )
+    if shell == "powershell":
+        return None
+    raise AssertionError("unreachable")
+
+
+def install_shell_completion(
+    target_path: Path, requested_shell: CompletionShell | None
+) -> CompletionInstallResult:
+    shell = requested_shell or detect_completion_shell()
+    if shell is None:
+        return CompletionInstallResult(
+            shell=None,
+            path=None,
+            status="skipped",
+            warning="未能从 SHELL 环境变量判断当前 shell，跳过补全安装",
+        )
+
+    completion_target = completion_target_for_shell(shell)
+    if completion_target is None:
+        return CompletionInstallResult(
+            shell=shell,
+            path=None,
+            status="skipped",
+            warning=f"当前 shell {shell} 没有可自动写入的用户级补全目录",
+        )
+
+    try:
+        result = subprocess.run(
+            [str(target_path), "completion", shell],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return CompletionInstallResult(
+            shell=shell,
+            path=completion_target.path,
+            status="skipped",
+            warning=f"生成 {shell} 补全脚本失败: {exc}",
+        )
+
+    status = write_text_atomic(completion_target.path, result.stdout)
+    return CompletionInstallResult(
+        shell=shell,
+        path=completion_target.path,
+        status=status,
+        warning=None,
+    )
+
+
 def target_key(target_path: Path) -> str:
     try:
         return str(target_path.resolve())
@@ -596,6 +776,31 @@ def path_warning(install_dir: Path, target_path: Path) -> str | None:
     return None
 
 
+def install_result(
+    *,
+    release: Release,
+    selected: SelectedAsset,
+    install_dir: Path,
+    target_path: Path,
+    auth_source: str,
+    status: Literal["installed", "updated", "unchanged"],
+    downloaded: bool,
+    completion_shell: CompletionShell | None,
+) -> InstallResult:
+    completion = install_shell_completion(target_path, completion_shell)
+    return InstallResult(
+        release=release,
+        selected=selected,
+        install_dir=install_dir,
+        target_path=target_path,
+        auth_source=auth_source,
+        path_warning=path_warning(install_dir, target_path),
+        status=status,
+        downloaded=downloaded,
+        completion=completion,
+    )
+
+
 def run_install(spec: InstallSpec) -> InstallResult:
     token = github_token()
     step(f"开始获取 openai/codex release 列表（auth: {token.source}）")
@@ -618,15 +823,15 @@ def run_install(spec: InstallSpec) -> InstallResult:
     current_state = state_status(target_path, release, selected)
     if current_state == "match":
         step("本地状态记录命中，跳过下载")
-        return InstallResult(
+        return install_result(
             release=release,
             selected=selected,
             install_dir=install_dir,
             target_path=target_path,
             auth_source=token.source,
-            path_warning=path_warning(install_dir, target_path),
             status="unchanged",
             downloaded=False,
+            completion_shell=spec.completion_shell,
         )
 
     if current_state == "stale":
@@ -634,15 +839,15 @@ def run_install(spec: InstallSpec) -> InstallResult:
     elif installed_version_matches(target_path, release):
         step("目标文件版本已是最新，跳过下载")
         save_state(make_state(target_path, release, selected, sha256_file(target_path)))
-        return InstallResult(
+        return install_result(
             release=release,
             selected=selected,
             install_dir=install_dir,
             target_path=target_path,
             auth_source=token.source,
-            path_warning=path_warning(install_dir, target_path),
             status="unchanged",
             downloaded=False,
+            completion_shell=spec.completion_shell,
         )
 
     step(f"开始下载 {selected.asset.name}，文件体积 {format_size(selected.asset.size)}")
@@ -658,15 +863,15 @@ def run_install(spec: InstallSpec) -> InstallResult:
     status = install_executable(executable, target_path)
     save_state(make_state(target_path, release, selected, sha256_bytes(executable)))
 
-    return InstallResult(
+    return install_result(
         release=release,
         selected=selected,
         install_dir=install_dir,
         target_path=target_path,
         auth_source=token.source,
-        path_warning=path_warning(install_dir, target_path),
         status=status,
         downloaded=True,
+        completion_shell=spec.completion_shell,
     )
 
 
@@ -681,9 +886,16 @@ def print_result(result: InstallResult) -> None:
     table.add_row("Auth", result.auth_source)
     table.add_row("Status", result.status)
     table.add_row("Downloaded", "yes" if result.downloaded else "no")
+    if result.completion.shell:
+        table.add_row("Completion shell", result.completion.shell)
+    if result.completion.path:
+        table.add_row("Completion path", str(result.completion.path))
+    table.add_row("Completion status", result.completion.status)
     console.print(table)
     if result.path_warning:
         console.print(f"[yellow]Warning:[/yellow] {result.path_warning}")
+    if result.completion.warning:
+        console.print(f"[yellow]Warning:[/yellow] {result.completion.warning}")
 
 
 @app.command(help="从 GitHub release 下载并安装最新 Codex CLI 预编译 binary。")
@@ -695,9 +907,16 @@ def main(
             help="安装目录；默认使用 $XDG_BIN_HOME，未设置时使用 ~/.local/bin",
         ),
     ] = None,
+    completion_shell: Annotated[
+        str | None,
+        typer.Option(
+            "--completion-shell",
+            help="要安装补全脚本的 shell；默认从 $SHELL 自动探测。可选：bash、elvish、fish、powershell、zsh",
+        ),
+    ] = None,
 ) -> None:
     try:
-        spec = InstallSpec(install_dir=install_dir)
+        spec = InstallSpec(install_dir=install_dir, completion_shell=completion_shell)
         result = run_install(spec)
     except (RuntimeError, ValidationError) as exc:
         console.print(f"[red]失败：{exc}[/red]")

--- a/scripts/tests/test_install_codex_cli.py
+++ b/scripts/tests/test_install_codex_cli.py
@@ -1,5 +1,6 @@
 import hashlib
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
@@ -112,6 +113,179 @@ class InstallCodexCliTest(unittest.TestCase):
         finally:
             for name, original in originals.items():
                 setattr(self.mod, name, original)
+
+    def test_completion_target_for_fish_uses_xdg_config_home(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            patches = {
+                "XDG_CONFIG_HOME": str(Path(temp_dir) / "config"),
+            }
+            old_values = {name: os.environ.get(name) for name in patches}
+            os.environ.update(patches)
+            try:
+                target = self.mod.completion_target_for_shell("fish")
+            finally:
+                for name, value in old_values.items():
+                    if value is None:
+                        os.environ.pop(name, None)
+                    else:
+                        os.environ[name] = value
+
+            self.assertEqual(
+                target,
+                self.mod.CompletionTarget(
+                    "fish",
+                    Path(temp_dir) / "config" / "fish" / "completions" / "codex.fish",
+                ),
+            )
+
+    def test_completion_target_for_bash_uses_xdg_data_home(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            patches = {
+                "XDG_DATA_HOME": str(Path(temp_dir) / "data"),
+            }
+            old_values = {name: os.environ.get(name) for name in patches}
+            os.environ.update(patches)
+            try:
+                target = self.mod.completion_target_for_shell("bash")
+            finally:
+                for name, value in old_values.items():
+                    if value is None:
+                        os.environ.pop(name, None)
+                    else:
+                        os.environ[name] = value
+
+            self.assertEqual(
+                target,
+                self.mod.CompletionTarget(
+                    "bash",
+                    Path(temp_dir)
+                    / "data"
+                    / "bash-completion"
+                    / "completions"
+                    / "codex.bash",
+                ),
+            )
+
+    def test_completion_target_for_zsh_requires_home_fpath_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir) / "home"
+            completion_dir = home / ".zsh" / "site-functions"
+            completion_dir.mkdir(parents=True)
+
+            patches = {
+                "zsh_fpath_dirs": lambda: [
+                    Path("/usr/share/zsh/site-functions"),
+                    completion_dir,
+                ],
+                "Path": self.mod.Path,
+            }
+            original_home = self.mod.Path.home
+            originals = {name: getattr(self.mod, name) for name in patches}
+            for name, replacement in patches.items():
+                setattr(self.mod, name, replacement)
+            self.mod.Path.home = classmethod(lambda cls: home)
+            try:
+                target = self.mod.completion_target_for_shell("zsh")
+            finally:
+                self.mod.Path.home = original_home
+                for name, original in originals.items():
+                    setattr(self.mod, name, original)
+
+            self.assertEqual(
+                target,
+                self.mod.CompletionTarget("zsh", completion_dir / "_codex"),
+            )
+
+    def test_install_shell_completion_generates_with_installed_binary(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target_path = Path(temp_dir) / "codex"
+            completion_path = Path(temp_dir) / "codex.fish"
+
+            calls = {}
+
+            def fake_run(args, **kwargs):
+                calls["args"] = args
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="complete -c codex -a exec\n",
+                    stderr="",
+                )
+
+            patches = {
+                "detect_completion_shell": lambda: "fish",
+                "completion_target_for_shell": lambda shell: self.mod.CompletionTarget(
+                    shell,
+                    completion_path,
+                ),
+                "subprocess": self.mod.subprocess,
+            }
+            original_run = self.mod.subprocess.run
+            originals = {name: getattr(self.mod, name) for name in patches}
+            for name, replacement in patches.items():
+                setattr(self.mod, name, replacement)
+            self.mod.subprocess.run = fake_run
+            try:
+                result = self.mod.install_shell_completion(target_path, None)
+            finally:
+                self.mod.subprocess.run = original_run
+                for name, original in originals.items():
+                    setattr(self.mod, name, original)
+
+            self.assertEqual(calls["args"], [str(target_path), "completion", "fish"])
+            self.assertEqual(
+                result,
+                self.mod.CompletionInstallResult(
+                    shell="fish",
+                    path=completion_path,
+                    status="installed",
+                ),
+            )
+            self.assertEqual(
+                completion_path.read_text(encoding="utf-8"),
+                "complete -c codex -a exec\n",
+            )
+
+    def test_install_shell_completion_honors_requested_shell(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target_path = Path(temp_dir) / "codex"
+            completion_path = Path(temp_dir) / "codex.fish"
+
+            calls = {}
+
+            def fake_run(args, **kwargs):
+                calls["args"] = args
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="complete -c codex -a exec\n",
+                    stderr="",
+                )
+
+            patches = {
+                "detect_completion_shell": lambda: "bash",
+                "completion_target_for_shell": lambda shell: self.mod.CompletionTarget(
+                    shell,
+                    completion_path,
+                ),
+                "subprocess": self.mod.subprocess,
+            }
+            original_run = self.mod.subprocess.run
+            originals = {name: getattr(self.mod, name) for name in patches}
+            for name, replacement in patches.items():
+                setattr(self.mod, name, replacement)
+            self.mod.subprocess.run = fake_run
+            try:
+                result = self.mod.install_shell_completion(target_path, "fish")
+            finally:
+                self.mod.subprocess.run = original_run
+                for name, original in originals.items():
+                    setattr(self.mod, name, original)
+
+            self.assertEqual(calls["args"], [str(target_path), "completion", "fish"])
+            self.assertEqual(result.shell, "fish")
+            self.assertEqual(result.path, completion_path)
+            self.assertEqual(result.status, "installed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

- `install_codex_cli.py` 已经是本地 Codex CLI 升级链路的一部分，升级后 shell completion 也应该同步刷新。
- shell completion 的用户级安装目录在不同 shell 下不同，需要按 fish/bash/zsh 的约定落到正确位置。

## What

- 安装或复用最新 Codex binary 后，自动调用 `codex completion <shell>` 生成 completion 并原子写入用户级目录。
- 新增 `--completion-shell`，可显式指定目标 shell；默认从 `$SHELL` 探测。
- 为 fish、bash、zsh 的目标路径和 completion 生成行为补充 unittest，并更新 README 说明。

## Risks

- 这会新增一个安装副作用：运行安装脚本时会尝试写入当前 shell 的用户级 completion 文件；无法判断或无法自动写入时会跳过并打印 warning。
