### PR TITLE
fix(codex)!: 要求 helper 使用宿主机 runtime

### DIFF
--- a/skills/codex-session-reader/scripts/codex_session_reader.py
+++ b/skills/codex-session-reader/scripts/codex_session_reader.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 import json
 import re
+import os
+import shutil
 import sys
 from typing import Annotated, Any, Literal, TypeVar
 
@@ -154,10 +156,26 @@ def validate_model_or_raise(
         raise CodexSessionReaderError(f"{label} 结构不合法。") from exc
 
 
+def resolve_codex_bin() -> str:
+    """Resolve the host Codex runtime and refuse the SDK-pinned fallback."""
+
+    explicit = os.environ.get("CODEX_BIN", "").strip()
+    if explicit:
+        return explicit
+    resolved = shutil.which("codex")
+    if resolved:
+        return resolved
+    raise CodexSessionReaderError(
+        "找不到宿主机 Codex binary：请安装 codex，确保它在 PATH 中，"
+        "或通过 CODEX_BIN 指定可执行文件路径。"
+    )
+
+
 def read_thread_via_sdk(thread_id: str, include_turns: bool) -> ThreadReadResponse:
     """通过官方 Codex Python SDK 调用 `thread/read`。"""
 
     config = CodexConfig(
+        codex_bin=resolve_codex_bin(),
         client_name="codex-session-reader",
         client_title="Codex Session Reader",
         experimental_api=False,

--- a/skills/git-workflow/scripts/codex_git_commit.py
+++ b/skills/git-workflow/scripts/codex_git_commit.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 
 from openai_codex import CodexConfig
 from openai_codex.client import CodexClient
@@ -34,10 +35,26 @@ def require_thread_id() -> str:
     return thread_id
 
 
+def resolve_codex_bin() -> str:
+    """Resolve the host Codex runtime and refuse the SDK-pinned fallback."""
+
+    explicit = os.environ.get("CODEX_BIN", "").strip()
+    if explicit:
+        return explicit
+    resolved = shutil.which("codex")
+    if resolved:
+        return resolved
+    raise RuntimeError(
+        "host Codex binary not found: install codex, make sure it is on PATH, "
+        "or set CODEX_BIN to the executable path"
+    )
+
+
 def resolve_model_name(thread_id: str) -> str:
     """通过 Codex SDK 解析 thread 当前 model 名。"""
 
     config = CodexConfig(
+        codex_bin=resolve_codex_bin(),
         client_name="codex-git-workflow",
         client_title="Codex Git Workflow",
         experimental_api=False,


### PR DESCRIPTION
## Why

- SDK 自带的 Codex runtime 可能落后于宿主机已安装版本，导致 thread/session 协议不兼容。
- 这些 helper 的目标是反映当前宿主环境，不应该静默降级到 SDK bundled runtime。

## What

- `codex-session-reader` 和 `git-workflow` 都改为只解析宿主机 Codex binary。
- 解析顺序是先使用 `CODEX_BIN`，再查找 PATH 中的 `codex`。
- 找不到宿主机 binary 时直接报错，并提示安装 `codex` 或设置 `CODEX_BIN`。

BREAKING CHANGE: 没有宿主机 `codex` 时，这两个 helper 不再回退到 SDK bundled runtime。需要把 `codex` 安装到 PATH，或通过 `CODEX_BIN` 指向可执行文件。
