### PR TITLE
fix(skills): 强化 Breaking Change 展示与模型解析

### DIFF
--- a/skills/change-request-writing/SKILL.md
+++ b/skills/change-request-writing/SKILL.md
@@ -27,6 +27,8 @@ description: 编写或更新 GitHub/GitLab Issue、PR、MR 的标题与正文；
 - 更新已有 PR/MR 正文时，不要在旧正文上做局部补丁；先回读当前正文，再基于 final net diff 重写完整正文并替换过时内容。
 - 如果正文经历过实验性修改，最终更新前重新审视完整 PR/MR body，确保它只描述最终 diff；不要写 `rerun`、`after removing`、`now`、`previously` 这类暴露过程的措辞，除非过程本身是 reviewer 需要审查的证据。
 - Breaking change 按 final net diff / 对外行为判断，不按中间 commit 机械继承；只有最终净变化确实破坏既有用法时，才在标题和正文标识。
+- PR/MR 存在 breaking change 时，正文默认使用独立的 `## BREAKING CHANGE` 章节，至少分别说明影响范围与迁移方式；不要只在正文末尾放一行普通的 `BREAKING CHANGE:` 文本。
+- Conventional Commit 的提交信息仍使用精确的 `BREAKING CHANGE:` footer；不要把提交 footer 语法机械套用为 PR/MR Markdown 的展示结构。
 
 ## Validation Gate
 
@@ -65,10 +67,10 @@ description: 编写或更新 GitHub/GitLab Issue、PR、MR 的标题与正文；
 默认标题与正文格式如下；如与团队、仓库、平台模板冲突，以既有约束为准。若有明确要求（如需中文），则优先遵循。
 
 1. 标题风格：英文、遵循语义化提交规范（如 `feat(scope): short summary`），简洁且描述核心目的；即使标题要求中文，语义化前缀仍需英文。
-2. 有 breaking change 时标题用 `type(scope)!: short summary`，正文加 `BREAKING CHANGE:` 说明影响和迁移方式；否则不要加 `!` 或 `BREAKING CHANGE:`。
+2. 有 breaking change 时标题用 `type(scope)!: short summary`，正文增加独立的 `## BREAKING CHANGE` 章节，明确列出影响范围与迁移方式；否则不要加 `!` 或 breaking change 章节。
 3. 描述风格：英文、短句和项目符号，优先让不看代码的读者快速理解动机、改动与影响，避免流水账与过多实现细节。涉及专有名词、函数名、方法名、类名、API 名称或配置键时，使用 inline code（反引号）包裹。
 4. 默认正文格式：
    - `## Why`：1-2 条短句说明为什么要做这次改动，聚焦问题背景或目标。
    - `## What`：1-3 条说明主要变更，聚焦功能或行为层面的变化，不罗列琐碎实现细节。
-5. 默认正文只包含 `## Why` 和 `## What`。不要添加 `## Validation`；只有通过上面的 Validation Gate 时才允许添加，否则省略。
-6. 可选正文块：仅在确有必要时添加 `BREAKING CHANGE:`、`## Risks` 或 `## Notes`。
+5. 默认正文只包含 `## Why` 和 `## What`；存在 breaking change 时必须再增加 `## BREAKING CHANGE`。不要添加 `## Validation`；只有通过上面的 Validation Gate 时才允许添加，否则省略。
+6. 可选正文块：仅在确有必要时添加 `## Risks` 或 `## Notes`。

--- a/skills/git-workflow/scripts/codex_git_commit.py
+++ b/skills/git-workflow/scripts/codex_git_commit.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.14"
 # dependencies = [
 #     "openai-codex>=0.1.0b3",
-#     "pydantic>=2.14.0a1",
+#     "pydantic>=2.13.4",
 #     "typer>=0.26.8",
 # ]
 # [tool.uv]

--- a/skills/git-workflow/scripts/codex_git_commit.py
+++ b/skills/git-workflow/scripts/codex_git_commit.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.14"
 # dependencies = [
 #     "openai-codex>=0.1.0b3",
+#     "pydantic>=2.14.0a1",
 #     "typer>=0.26.8",
 # ]
 # [tool.uv]
@@ -20,10 +21,17 @@ import shutil
 from openai_codex import CodexConfig
 from openai_codex.client import CodexClient
 from openai_codex.errors import CodexError
+from pydantic import BaseModel
 import typer
 
 AGENT_NAME = "Codex"
 app = typer.Typer(add_completion=False, help="输出当前 Codex agent/model 的 JSON。")
+
+
+class ThreadModelResponse(BaseModel):
+    """只解析 thread/resume 中提交信息需要的 model 字段。"""
+
+    model: str | None = None
 
 
 def require_thread_id() -> str:
@@ -62,7 +70,11 @@ def resolve_model_name(thread_id: str) -> str:
     try:
         with CodexClient(config) as client:
             client.initialize()
-            response = client.thread_resume(thread_id)
+            response = client.request(
+                "thread/resume",
+                {"threadId": thread_id},
+                response_model=ThreadModelResponse,
+            )
     except CodexError as exc:
         raise RuntimeError(f"failed to resolve model via Codex SDK: {exc}") from exc
     except OSError as exc:

--- a/skills/git-workflow/scripts/tests/test_codex_git_commit.py
+++ b/skills/git-workflow/scripts/tests/test_codex_git_commit.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "codex_git_commit.py"
+SPEC = importlib.util.spec_from_file_location("codex_git_commit", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+codex_git_commit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(codex_git_commit)
+
+
+class ResolveModelNameTest(unittest.TestCase):
+    def test_reads_only_model_without_validating_thread_turns(self) -> None:
+        client = mock.MagicMock()
+        client.__enter__.return_value = client
+        client.request.return_value = SimpleNamespace(model="gpt-test")
+        client.thread_resume.side_effect = AssertionError(
+            "thread_resume must not parse the complete thread history"
+        )
+
+        with (
+            mock.patch.object(codex_git_commit, "CodexClient", return_value=client),
+            mock.patch.object(
+                codex_git_commit, "resolve_codex_bin", return_value="/usr/bin/codex"
+            ),
+        ):
+            got = codex_git_commit.resolve_model_name("thread-id")
+
+        self.assertEqual(got, "gpt-test")
+        client.request.assert_called_once()
+        method, params = client.request.call_args.args
+        self.assertEqual(method, "thread/resume")
+        self.assertEqual(params, {"threadId": "thread-id"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

- PR/MR 中仅用普通 footer 描述 breaking change 不够醒目，reviewer 容易忽略接口兼容性影响。
- `codex_git_commit.py` 会让 SDK 解析完整 thread 历史；当运行时新增 SDK 尚未支持的事件类型时，即使只需要读取模型名称也会失败。

## What

- 要求存在 breaking change 的 PR/MR 使用独立的 `## BREAKING CHANGE` 章节，并明确影响范围与迁移方式；同时保留 Conventional Commit 的 footer 语义。
- 模型查询改为仅解析 `thread/resume` 返回的顶层 `model` 字段，避免无关的历史事件 schema 演进阻断提交辅助流程。
- 增加回归测试，覆盖完整 thread 恢复不可用时仍能读取模型名称的场景。
