### PR TITLE
feat(jira-cli): 支持查询 Saved Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ notification_method = "bel"
 | [`codex-session-reader`](skills/codex-session-reader/SKILL.md) | 读取 Codex 的单个 session/thread；当已知 thread id 且需要查看或摘要会话内容时使用。 |
 | [`codex-thread-namer`](skills/codex-thread-namer/SKILL.md) | 为当前 Codex thread 设置名称；默认根据上下文直接重命名，仅在用户明确要求时提供候选名。 |
 | [`confluence-cli`](skills/confluence-cli/SKILL.md) | 查询、检索与阅读 Confluence 文档/页面。 |
-| [`jira-cli`](skills/jira-cli/SKILL.md) | 通过内置 Python CLI 查询和管理 Jira Issue、流转与评论。 |
+| [`jira-cli`](skills/jira-cli/SKILL.md) | 通过内置 Python CLI 查询和管理 Jira Issue、Saved Filter、流转与评论。 |
 | [`uv-cli-creator`](skills/uv-cli-creator/SKILL.md) | 为本仓库创建或修改 uv --script 风格的 Python CLI；当需要把重复命令封装成 `./scripts/...` 直接执行的工具时使用。 |
 | [`dcjanus-preferences`](skills/dcjanus-preferences/SKILL.md) | 记录 DCjanus 在不同语言中偏好的第三方库与使用场景，供 AI 在选型、引入依赖或替换库时优先参考。适用于 Python/Rust/Go 的库选择、技术方案对比、或需要遵循 DCjanus 个人偏好进行开发的场景。 |
 | [`domain-modeling`](skills/domain-modeling/SKILL.md) | 构建并持续校准领域模型，明确领域术语与边界，并在必要时记录重要架构决策。 |

--- a/skills/jira-cli/SKILL.md
+++ b/skills/jira-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jira-cli
-description: 通过内置 Python CLI 直接调用 Jira Server/Data Center REST API v2，查询、创建、编辑、流转和删除 Issue、Epic、Sub-task、评论、附件、关联、Watcher、Vote 与 Worklog，并查询项目、字段、Board 和 Sprint。适用于需要可控地操作 Jira、保留 Jira wiki markup 并精确管理请求与输出的场景。
+description: 通过内置 Python CLI 直接调用 Jira Server/Data Center REST API v2，查询、创建、编辑、流转和删除 Issue、Epic、Sub-task、评论、附件、关联、Watcher、Vote 与 Worklog，并查询 Saved Filter、项目、字段、Board 和 Sprint。适用于需要可控地操作 Jira、保留 Jira wiki markup 并精确管理请求与输出的场景。
 ---
 
 # Jira CLI
@@ -110,6 +110,8 @@ Jira 管理员可以按字段配置 renderer，插件也可能增减宏。需要
 ./scripts/jira_cli.py metadata fields
 ./scripts/jira_cli.py metadata issue-types
 ./scripts/jira_cli.py metadata create --project SATOS --type Task
+./scripts/jira_cli.py filter favourites
+./scripts/jira_cli.py filter get 157700
 ./scripts/jira_cli.py issue list --jql 'assignee = currentUser() ORDER BY updated DESC'
 ./scripts/jira_cli.py board list --project SATOS
 ./scripts/jira_cli.py sprint list 12345
@@ -129,6 +131,25 @@ Jira 管理员可以按字段配置 renderer，插件也可能增减宏。需要
 ./scripts/jira_cli.py api get rest/api/2/priority
 ./scripts/jira_cli.py api get rest/api/2/search --param 'jql=project = SATOS'
 ```
+
+## Saved Filter
+
+`filter favourites` 使用 Jira Server 8.20 的公开
+`GET /rest/api/2/filter/favourite` 接口，只返回当前认证用户收藏且有权查看的 Filter；
+结果不等于当前用户拥有的全部 Filter。当前版本没有列出 owned Filter 的公开 REST
+接口；不得把 Favorite 结果按 owner 过滤后宣称为完整 owned 列表，也不要改用 Jira
+内部接口或 HTML 抓取。
+
+```bash
+./scripts/jira_cli.py filter favourites
+./scripts/jira_cli.py --json filter favourites --expand owner --expand sharePermissions
+./scripts/jira_cli.py --json filter get 157700
+./scripts/jira_cli.py issue list --jql 'filter = 157700'
+```
+
+`filter get` 返回当前用户有权查看的指定 Filter，包括其 JQL。要检索 Filter 对应的
+Issue，继续使用 `issue list --jql 'filter = FILTER_ID'`，不在 CLI 中引入额外作用域
+或层级展开语义。
 
 ## Issue 与 Epic
 

--- a/skills/jira-cli/agents/openai.yaml
+++ b/skills/jira-cli/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Jira CLI"
-  short_description: "通过内置 Python CLI 安全管理 Jira 日常工作流"
-  default_prompt: "Use $jira-cli to inspect and manage Jira Server issues through the bundled Python CLI."
+  short_description: "通过内置 Python CLI 查询和管理 Jira 工作项与过滤器"
+  default_prompt: "Use $jira-cli to inspect Jira Server issues and saved filters or perform controlled issue updates through the bundled Python CLI."

--- a/skills/jira-cli/scripts/jira_api_client.py
+++ b/skills/jira-cli/scripts/jira_api_client.py
@@ -197,6 +197,19 @@ class JiraApiClient:
     def list_issue_types(self) -> list[dict[str, Any]]:
         return self.request("GET", "rest/api/2/issuetype")
 
+    def list_favourite_filters(
+        self, *, expand: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        params = {"expand": ",".join(expand)} if expand else None
+        return self.request("GET", "rest/api/2/filter/favourite", params=params)
+
+    def get_filter(
+        self, filter_id: str, *, expand: list[str] | None = None
+    ) -> dict[str, Any]:
+        filter_id = self._segment(filter_id, "filter_id")
+        params = {"expand": ",".join(expand)} if expand else None
+        return self.request("GET", f"rest/api/2/filter/{filter_id}", params=params)
+
     def create_meta(
         self,
         *,

--- a/skills/jira-cli/scripts/jira_cli.py
+++ b/skills/jira-cli/scripts/jira_cli.py
@@ -43,6 +43,7 @@ from jira_config import (  # noqa: E402
 app = typer.Typer(help="Manage Jira Server/Data Center through REST API v2.")
 config_app = typer.Typer(help="Manage jira-cli TOML configuration.")
 user_app = typer.Typer(help="Inspect Jira users.")
+filter_app = typer.Typer(help="Inspect Jira saved filters.")
 project_app = typer.Typer(help="Inspect projects, versions, and components.")
 metadata_app = typer.Typer(help="Inspect fields and issue creation metadata.")
 issue_app = typer.Typer(help="Read and update Jira issues.")
@@ -60,6 +61,7 @@ api_app = typer.Typer(help="Access unwrapped read-only REST endpoints.")
 for name, group in {
     "config": config_app,
     "user": user_app,
+    "filter": filter_app,
     "project": project_app,
     "metadata": metadata_app,
     "issue": issue_app,
@@ -608,6 +610,41 @@ def user_search(
     _print_result(
         ctx, _state(ctx).client().search_users(query, max_results=max_results)
     )
+
+
+@filter_app.command("favourites")
+def filter_favourites(
+    ctx: typer.Context,
+    expand: Annotated[list[str] | None, typer.Option("--expand")] = None,
+) -> None:
+    """List the authenticated user's favourite filters."""
+    state = _state(ctx)
+    result = state.client().list_favourite_filters(expand=expand)
+    if state.json_output:
+        _print_json(result)
+        return
+    table = Table("ID", "Name", "Owner", "JQL")
+    for saved_filter in result:
+        owner = saved_filter.get("owner") or {}
+        table.add_row(
+            _plain_text(saved_filter.get("id", "")),
+            _plain_text(saved_filter.get("name", "")),
+            _plain_text(
+                owner.get("displayName") or owner.get("name") or owner.get("key") or ""
+            ),
+            _plain_text(saved_filter.get("jql", "")),
+        )
+    console.print(table)
+
+
+@filter_app.command("get")
+def filter_get(
+    ctx: typer.Context,
+    filter_id: str,
+    expand: Annotated[list[str] | None, typer.Option("--expand")] = None,
+) -> None:
+    """Get one visible saved filter by ID."""
+    _print_result(ctx, _state(ctx).client().get_filter(filter_id, expand=expand))
 
 
 @project_app.command("list")

--- a/skills/jira-cli/scripts/tests/test_jira_api_client.py
+++ b/skills/jira-cli/scripts/tests/test_jira_api_client.py
@@ -53,6 +53,32 @@ class JiraApiClientTest(unittest.TestCase):
         )
         self.assertEqual(result["total"], 0)
 
+    def test_filter_reads_use_jira_server_public_endpoints(self):
+        responses = {
+            "/rest/api/2/filter/favourite": [
+                {"id": "157700", "name": "Team epics", "favourite": True}
+            ],
+            "/rest/api/2/filter/157700": {
+                "id": "157700",
+                "name": "Team epics",
+                "jql": "type = Epic",
+            },
+        }
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            self.assertEqual(request.method, "GET")
+            self.assertEqual(request.url.params["expand"], "owner,sharePermissions")
+            return httpx2.Response(200, json=responses[request.url.path])
+
+        client = self.make_client(handler)
+        favourites = client.list_favourite_filters(expand=["owner", "sharePermissions"])
+        filter_details = client.get_filter(
+            "157700", expand=["owner", "sharePermissions"]
+        )
+
+        self.assertEqual(favourites[0]["id"], "157700")
+        self.assertEqual(filter_details["jql"], "type = Epic")
+
     def test_create_metadata_uses_repeated_multi_value_parameters(self):
         def handler(request: httpx2.Request) -> httpx2.Response:
             self.assertEqual(

--- a/skills/jira-cli/scripts/tests/test_jira_cli.py
+++ b/skills/jira-cli/scripts/tests/test_jira_cli.py
@@ -282,6 +282,21 @@ class JiraCliTest(unittest.TestCase):
         self.assertEqual(upsert_help.exit_code, 0, upsert_help.output)
         self.assertIn("--global-id", Text.from_ansi(upsert_help.output).plain)
 
+    def test_filter_commands_expose_favourites_and_filter_details(self):
+        favourites_help = self.runner.invoke(
+            self.cli.app, ["filter", "favourites", "--help"]
+        )
+        old_list = self.runner.invoke(self.cli.app, ["filter", "list"])
+        get_help = self.runner.invoke(self.cli.app, ["filter", "get", "--help"])
+
+        self.assertEqual(favourites_help.exit_code, 0, favourites_help.output)
+        self.assertIn(
+            "favourite filters", Text.from_ansi(favourites_help.output).plain.lower()
+        )
+        self.assertNotEqual(old_list.exit_code, 0, old_list.output)
+        self.assertEqual(get_help.exit_code, 0, get_help.output)
+        self.assertIn("filter_id", Text.from_ansi(get_help.output).plain.lower())
+
     def test_parse_pairs_accepts_json_and_plain_text(self):
         parsed = self.cli._parse_pairs(['labels=["one","two"]', "customfield_1=plain"])
         self.assertEqual(parsed["labels"], ["one", "two"])

--- a/skills/tampermonkey-cli/scripts/tampermonkey.py
+++ b/skills/tampermonkey-cli/scripts/tampermonkey.py
@@ -5,7 +5,7 @@
 #     "pydantic>=2.13.4",
 #     "rich>=15.0.0",
 #     "typer>=0.27.0",
-#     "websockets>=16.1.1",
+#     "websockets>=17.0",
 # ]
 # ///
 


### PR DESCRIPTION
## Why

- Jira 实例与项目由多个团队共享，需要方便地发现并复用当前用户收藏的 Saved Filter。
- 现有 CLI 只能通过通用 `api get` 访问 Filter，命令语义和返回边界不够直观。

## What

- 新增 `filter favourites`，通过 Jira Server 公开 API 列出当前用户收藏且有权查看的 Filter。
- 新增 `filter get <id>`，查询指定 Filter 的 JQL 等详情，并支持原始 JSON 与 `expand` 参数。
- 在 skill 文档中明确 Favorite Filters 不等于全部 owned Filters，并补充对应测试与使用示例。
- 将 Tampermonkey CLI 的 `websockets` 依赖下限同步到 17.0，满足仓库依赖版本门禁。
