### PR TITLE
docs(skills): 补充 clap 偏好并精简提交正文规则

### DIFF
--- a/skills/dcjanus-preferences/references/rust.md
+++ b/skills/dcjanus-preferences/references/rust.md
@@ -5,7 +5,9 @@
 - jiff: 自己控制的新应用默认优先选择的日期与时间库，尤其适合 IANA 时区、DST、日历跨度、当地时间歧义处理，以及需要保留时区标识的序列化场景。若选用版本尚未达到 1.0，用于公共 library API 时需额外评估稳定性；性能敏感路径应按实际 workload 做 benchmark。
 - chrono: 不作为新项目的默认日期与时间库；当既有项目已稳定使用、上下游公共 API 依赖 Chrono，或实测性能更合适时继续使用，不因软弃用信号本身而进行无收益的紧急迁移。
 - time: 日期与时间处理库，标准库兼容且支持 `no_std` 场景。
-- clap: Rust 命令行参数解析库，适合构建 CLI 工具与子命令解析。
+- clap / clap_complete: Rust CLI 默认优先使用 clap 的 Derive API，通过 `#[derive(Parser)]`、`Args`、`Subcommand` 和 `ValueEnum` 将参数、可复用参数组、子命令和枚举值建模为强类型；除非命令结构必须在运行时动态生成，或 Derive API 无法清晰表达需求，否则不要以 Builder API 为主要实现方式。确有需要时可以通过 `CommandFactory`、`augment_args` 等官方互操作能力局部混用 Builder API。
+- clap 动态补全: 需要 shell 补全时，若项目能够接受尚未承诺稳定性的 API，默认优先启用 `clap_complete` 的 `unstable-dynamic` feature 并使用 `CompleteEnv`，让补全时运行当前程序并基于实时命令、路径或业务候选值生成结果；仅在发布环境不能执行目标程序、稳定性要求不允许使用 unstable feature，或必须分发独立脚本时，回退到 `clap_complete::aot` 静态补全。`CompleteEnv::complete` 应在普通参数解析及任何 stdout 输出之前执行。
+- clap 补全安装: 面向用户的 CLI 最好提供类似 `completion install --shell <auto|bash|elvish|fish|powershell|zsh>` 的子命令，默认允许 `auto` 根据 `SHELL` 等平台信息检测，也允许显式指定 shell。安装逻辑由项目实现，必须幂等、避免重复写入，并明确告知修改的配置文件及手工安装方式；动态补全优先写入一条在 shell 启动时重新执行并 source/eval `COMPLETE=<shell> <program>` 注册输出的钩子，不要长期缓存注册脚本，因为 `unstable-dynamic` 的二进制与 shell 侧协议没有稳定性保证。
 - serde: Rust 结构体序列化/反序列化框架，适合配置、网络传输、持久化等场景。
 - serde_json: Serde 生态的 JSON 处理库，适合 JSON 的解析、校验与序列化。
 - ratatui: Rust 的 TUI（终端用户界面）框架，适合构建终端交互应用与仪表盘。

--- a/skills/repository-workflow/SKILL.md
+++ b/skills/repository-workflow/SKILL.md
@@ -33,7 +33,7 @@ description: 处理从本地 Git 变更到 GitHub/GitLab 协作发布的完整�
 ## 创建 commit
 
 1. 完整读取 [commit-messages.md](references/commit-messages.md)，并根据最终待提交内容生成 message。
-2. 把结构化提交描述写入仓库外的临时 YAML 文件；不要在 shell 参数中拼接多行正文。YAML 格式见 [commit-messages.md](references/commit-messages.md)。
+2. 把结构化提交描述写入仓库外的临时 YAML 文件。默认只写 `subject` 和 `paths`；仅当标题与 diff 无法充分解释必要的动机、约束或影响时才添加 `body`，不要机械生成提交正文。需要正文时也不要在 shell 参数中拼接多行文本。YAML 格式与正文判断标准见 [commit-messages.md](references/commit-messages.md)。
 3. 从本 skill 目录运行提交脚本，并显式传入目标仓库。支持 `env -S` 时直接执行；不要使用 `python` 或 `uv run python`：
 
 ```bash

--- a/skills/repository-workflow/references/commit-messages.md
+++ b/skills/repository-workflow/references/commit-messages.md
@@ -8,7 +8,14 @@
 - `type` 必须存在。仓库没有额外约定时，优先使用 `feat`、`fix`、`refactor`、`docs`、`test` 或 `chore`。
 - 只有 scope 能准确表达影响边界时才添加；不要为了格式完整而猜测。
 - summary 描述最终结果，不记录执行过程、工具操作或临时状态。
-- 只有标题不足以解释动机、约束或影响时才添加正文。
+- 默认只写 subject。大部分边界清晰的简单提交不需要正文。
+
+## 正文
+
+- 先判断 reviewer 是否仍需要从 commit message 获得无法由 subject 和 diff 自然推导的重要信息；没有则完全省略 `body`。
+- 仅在需要解释非显然的动机、决定性约束、重要行为影响、迁移要求或关键设计取舍时添加正文。
+- 不要用正文复述 subject、罗列修改文件或实现步骤、汇报普通测试与检查、描述工具操作，或补充“暂未引入依赖”等对理解提交没有实际帮助的信息。
+- 正文只保留理解和维护该提交所必需的内容，不套用固定的“背景 / 处理 / 验证”模板。
 
 ## 结构化 YAML
 
@@ -20,21 +27,12 @@ paths:
   - src/main/java/example/AuthService.java
 ```
 
-带中文正文的完整配置：
+确实需要解释关键约束时才添加 `body`：
 
 ```yaml
 subject: "chore(toolchain): configure JDK 17 with mise"
 body: |
-  背景：
-
-  项目以 Java 17 为目标。
-
-  处理：
-  - 新增仓库级 mise 配置。
-  - 允许团队成员复用相同工具链。
-
-  验证：
-  - Maven 测试通过。
+  生产构建环境固定使用 JDK 17；仓库级配置用于避免本地与 CI 选择不同工具链。
 trailers:
   - key: Reviewed-by
     value: DCjanus <DCjanus@dcjanus.com>
@@ -43,7 +41,7 @@ paths:
 ```
 
 - `subject` 必填，必须符合 Conventional Commits。
-- `body`、`trailers`、`paths` 可选；`body` 是自由多行字符串，内部 Markdown 与换行完全由调用方控制。
+- `body`、`trailers`、`paths` 可选；不满足上述正文条件时不要写 `body`。确需正文时，它是自由多行字符串，内部 Markdown 与换行完全由调用方控制。
 - `paths` 必须是仓库相对路径；非空时脚本使用 `git commit --only`，为空时提交当前 index。
 - `trailers` 是 `key` / `value` 结构化列表；key 仅支持字母、数字和连字符，value 必须是非空单行字符串。
 - `Assisted-by` 由脚本生成，禁止放入 `trailers`。


### PR DESCRIPTION
## Why

- 现有 Rust 偏好只记录了 clap 的适用场景，无法指导 API 风格和补全方案的选择。
- 动态补全及其安装方式存在稳定性和维护边界，需要形成一致约定。
- 提交流程虽然允许省略正文，但约束不够明确，容易为简单提交机械生成没有信息增量的 body。

## What

- 明确 clap 默认优先使用 Derive API，并说明局部使用 Builder API 的条件。
- 优先采用 `clap_complete` 的动态补全能力，同时保留静态补全的适用边界。
- 约定提供支持自动检测或显式指定 shell 的幂等安装子命令，并在 shell 启动时重新加载动态注册代码。
- 将 commit body 调整为例外：默认只写 subject，仅在需要解释非显然动机、关键约束、重要影响、迁移要求或设计取舍时添加正文。
