### PR TITLE
docs(skills): 规范临时输入文件清理

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ notification_method = "bel"
 
 ### grill-me
 
-本仓库中的 [`grill-me`](skills/grill-me/SKILL.md) 改编自 Matt Pocock 的原始 [`grilling`](https://github.com/mattpocock/skills/blob/bfdaef8e989a5c81160e74bc5043bd434da49cac/skills/productivity/grilling/SKILL.md)，基于上游 commit [`bfdaef8e989a5c81160e74bc5043bd434da49cac`](https://github.com/mattpocock/skills/commit/bfdaef8e989a5c81160e74bc5043bd434da49cac)，按 [MIT License](licenses/grill-me/LICENSE) 使用和修改。
+本仓库中的 [`grill-me`](skills/grill-me/SKILL.md) 改编自 Matt Pocock 的原始 [`grilling`](https://github.com/mattpocock/skills/blob/86cba45f4244b2545112d13e77ba82eb2bfad325/skills/productivity/grilling/SKILL.md)，基于上游 commit [`86cba45f4244b2545112d13e77ba82eb2bfad325`](https://github.com/mattpocock/skills/commit/86cba45f4244b2545112d13e77ba82eb2bfad325)，按 [MIT License](licenses/grill-me/LICENSE) 使用和修改。
 
 ### domain-modeling
 

--- a/skills/confluence-cli/SKILL.md
+++ b/skills/confluence-cli/SKILL.md
@@ -40,6 +40,10 @@ python skills/confluence-cli/scripts/confluence_cli.py --json page get --page-id
 
 4) 注意事项
 - `page get` 默认保持普通缓存读；刚更新页面后需要校验正文时，使用 `--fresh` 绕过 Confluence 或代理缓存，例如：`./scripts/confluence_cli.py --json page get --page-id ... --body-format storage --expand body.storage,version --fresh`
+- 如果 Markdown 文件由 Agent 为当前单次发布临时创建，且成功后不再复用，在同一次
+  shell 调用中把发布命令与 `rm -- <明确路径>` 用 `&&` 串行执行。发布失败时保留文件，
+  不要使用 `;` 无条件删除，也不要用变量、通配符或目录作为清理目标。用户提供的源文档、
+  仓库文件和本地图片不得随 Markdown 临时文件自动删除。
 
 5) 附件下载示例
 - 下载指定附件（可重复传入 `--name`）：`./scripts/confluence_cli.py attachment download --page-id 3060336952 --output-dir ./attachments --name a.png --name b.png`
@@ -48,6 +52,7 @@ python skills/confluence-cli/scripts/confluence_cli.py --json page get --page-id
 
 6) 发布 Markdown 示例
 - 发布到父页面（同名则更新）：`./scripts/confluence_cli.py --json page publish-markdown --parent-id 3061931928 --title "批量重置 Offset 功能测试" --markdown-path /path/to/doc.md`
+- 发布单次临时 Markdown 并在成功后清理：`./scripts/confluence_cli.py --json page publish-markdown --parent-id 3061931928 --title "批量重置 Offset 功能测试" --markdown-path /tmp/confluence-page.md && rm -- /tmp/confluence-page.md`
 - Markdown 表格支持 `:---`、`:---:`、`---:` 这类左对齐、居中、右对齐语法，会转换为 Confluence storage 的 table cell `text-align` 样式。
 - 本地图片发布时会按最大展示框自动生成单个 Confluence 尺寸属性：默认最大宽度 `1000`、最大高度 `800`，可用 `--image-max-width` / `--image-max-height` 覆盖；只写触发缩放的 `ac:width` 或 `ac:height`，不修改附件原图。
 - 如需覆盖单张图片展示尺寸，可使用 Markdown title：`![图](./a.png "confluence-width=1200")`、`![图](./a.png "confluence-height=600")`、`![图](./a.png "confluence-size=original")`。

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -18,6 +18,14 @@ description: 使用 GitHub CLI 与 GitHub 资源交互；适用于 repo、issue�
 ./scripts/github_preflight.py --help
 ```
 
+## 临时输入文件清理
+
+- 如果输入文件由 Agent 为当前单次操作临时创建，且成功后不再复用，在同一次 shell
+  调用中把最终写操作与 `rm -- <明确路径>` 用 `&&` 串行执行。写操作失败时保留文件，
+  不要使用 `;` 无条件删除，也不要用变量、通配符或目录作为清理目标。
+- dry-run 后仍要用于正式创建的正文不能提前删除；把清理命令串在正式创建之后。
+- 用户提供的文件、仓库文件，以及后续更新或校验仍需复用的文件不得自动清理。
+
 ## 常用场景
 
 - 仓库、Issue、PR、评论、release、workflow 等资源，优先先用 `gh <group> --help` 确认是否有现成子命令，再执行。
@@ -84,6 +92,17 @@ description: 使用 GitHub CLI 与 GitHub 资源交互；适用于 repo、issue�
 10. 只有脚本明确报告不支持当前平台能力、且无法安全扩展时，才回退网页表单；回复中要说明回退原因。
 11. 创建成功并验证通过后，输出完整 Issue URL。
 
+正式创建并清理单次临时正文的示例：
+
+```bash
+./scripts/github_issue.py create \
+  --repo owner/repo \
+  --template bug.yml \
+  --title "..." \
+  --body-file /tmp/issue-body.md \
+  && rm -- /tmp/issue-body.md
+```
+
 ## 创建 PR
 
 以下规范建立在“创建前检查”已完成的前提上。
@@ -97,7 +116,8 @@ description: 使用 GitHub CLI 与 GitHub 资源交互；适用于 repo、issue�
 gh pr create \
   --title "..." \
   --body-file /tmp/pr-body.md \
-  --base main
+  --base main \
+  && rm -- /tmp/pr-body.md
 ```
 6. 修改 PR 时也复用本地文件，避免手工编辑，例如：`gh pr edit <id> --title "..." --body-file /tmp/pr-body.md`。
 7. 创建成功后，输出完整 PR URL。

--- a/skills/gitlab-cli/SKILL.md
+++ b/skills/gitlab-cli/SKILL.md
@@ -31,12 +31,20 @@ python skills/gitlab-cli/scripts/gitlab_cli.py --help
 - 创建或更新 MR / Issue 时，正文必须通过 `--description-file <path>` 传入。
 - 不要使用 shell 直接传多行正文；脚本不支持 `--description`。
 - `--title` 这类短文本参数可以直接传，长正文一律先写到文件里再引用。
+- 如果正文文件由 Agent 为当前单次操作临时创建，且成功后不再复用，在同一次 shell
+  调用中把最终写操作与 `rm -- <明确路径>` 用 `&&` 串行执行。写操作失败时保留文件，
+  不要使用 `;` 无条件删除，也不要用变量、通配符或目录作为清理目标。
 
 示例：
 
 ```bash
 # 正确
 ./scripts/gitlab_cli.py mr update --cwd /path/to/repo 123 --description-file /tmp/mr-body.md
+
+# 临时正文成功写入后立即清理
+./scripts/gitlab_cli.py mr update --cwd /path/to/repo 123 \
+  --description-file /tmp/mr-body.md \
+  && rm -- /tmp/mr-body.md
 
 # 错误
 ./scripts/gitlab_cli.py mr update --cwd /path/to/repo 123 --description "multi-line body"

--- a/skills/google-sheets-cli/SKILL.md
+++ b/skills/google-sheets-cli/SKILL.md
@@ -58,8 +58,14 @@ OAuth 通常只需要配置一次；日常任务不要把认证细节加载进�
 ```bash
 ./scripts/gsheets_cli.py --json values batch-update \
   --spreadsheet-id <spreadsheet-id> \
-  --updates-json @/tmp/sheets-updates.json
+  --updates-json @/tmp/sheets-updates.json \
+  && rm -- /tmp/sheets-updates.json
 ```
+
+如果 JSON 文件由 Agent 为当前单次写操作临时创建，且成功后不再复用，在同一次 shell
+调用中把写操作与 `rm -- <明确路径>` 用 `&&` 串行执行。写操作失败时保留文件，不要
+使用 `;` 无条件删除，也不要用变量、通配符或目录作为清理目标。用户提供的 JSON、
+写入前的范围备份，以及后续验证或回滚仍需复用的文件不得自动清理。
 
 ## 读取格式与 table 元数据
 

--- a/skills/jira-cli/SKILL.md
+++ b/skills/jira-cli/SKILL.md
@@ -48,6 +48,10 @@ cd skills/jira-cli
 - `--json` 保留 Jira 原始响应结构，适合 Agent 和脚本处理。
 - 普通模式提供 Rich 摘要或表格。
 - 复杂正文优先写入临时文件，再用 `--description-file` 或 `--body-file` 传递。
+- 如果正文文件由 Agent 为当前单次操作临时创建，且成功后不再复用，在同一次 shell
+  调用中把最终写操作与 `rm -- <明确路径>` 用 `&&` 串行执行。写操作失败时保留文件，
+  不要使用 `;` 无条件删除，也不要用变量、通配符或目录作为清理目标。用户提供的文件、
+  附件和后续操作仍需复用的文件不得自动清理。
 - 额外字段使用重复的 `--field KEY=JSON_OR_TEXT`。
 - 涉及“我”、当前用户、负责人、报告人等身份语义时，先执行
   `./scripts/jira_cli.py --json user me` 获取当前 Jira 认证身份。不得根据会话称呼、
@@ -159,7 +163,8 @@ Issue，继续使用 `issue list --jql 'filter = FILTER_ID'`，不在 CLI 中引
 ./scripts/jira_cli.py issue create \
   --type Task \
   --summary '中文任务标题' \
-  --description-file /tmp/description.txt
+  --description-file /tmp/description.txt \
+  && rm -- /tmp/description.txt
 
 ./scripts/jira_cli.py issue create \
   --type Sub-task \
@@ -198,7 +203,8 @@ Epic 使用配置中的 `epic_name_field` 和 `epic_link_field`：
 评论正文遵循上面的 Jira wiki markup 规则；外部资源使用带简洁显示文本的链接。
 
 ```bash
-./scripts/jira_cli.py comment add SATOS-261728 --body-file /tmp/comment.txt
+./scripts/jira_cli.py comment add SATOS-261728 --body-file /tmp/comment.txt \
+  && rm -- /tmp/comment.txt
 ./scripts/jira_cli.py comment edit SATOS-261728 22384028 --body-file /tmp/comment.txt
 ./scripts/jira_cli.py comment list SATOS-261728
 ```

--- a/skills/repository-workflow/SKILL.md
+++ b/skills/repository-workflow/SKILL.md
@@ -34,17 +34,22 @@ description: 处理从本地 Git 变更到 GitHub/GitLab 协作发布的完整�
 
 1. 完整读取 [commit-messages.md](references/commit-messages.md)，并根据最终待提交内容生成 message。
 2. 把结构化提交描述写入仓库外的临时 YAML 文件。默认只写 `subject` 和 `paths`；仅当标题与 diff 无法充分解释必要的动机、约束或影响时才添加 `body`，不要机械生成提交正文。需要正文时也不要在 shell 参数中拼接多行文本。YAML 格式与正文判断标准见 [commit-messages.md](references/commit-messages.md)。
-3. 从本 skill 目录运行提交脚本，并显式传入目标仓库。支持 `env -S` 时直接执行；不要使用 `python` 或 `uv run python`：
+3. 从本 skill 目录运行提交脚本，并显式传入目标仓库。提交成功后不再需要临时 YAML
+   时，在同一次 shell 调用中用 `&& rm -- <明确路径>` 清理；提交失败时保留文件，
+   不要使用 `;` 无条件删除，也不要用变量、通配符或目录作为清理目标。支持 `env -S`
+   时直接执行；不要使用 `python` 或 `uv run python`：
 
 ```bash
-./scripts/commit_from_yaml.py /tmp/commit.yaml --repo /path/to/repository
+./scripts/commit_from_yaml.py /tmp/commit.yaml --repo /path/to/repository \
+  && rm -- /tmp/commit.yaml
 ```
 
 不支持 `env -S` 时使用：
 
 ```bash
 uv run --script scripts/commit_from_yaml.py \
-  /tmp/commit.yaml --repo /path/to/repository
+  /tmp/commit.yaml --repo /path/to/repository \
+  && rm -- /tmp/commit.yaml
 ```
 
 脚本默认从当前 Codex thread 自动解析模型并生成 `Assisted-by: Codex:<model>`。自动探测不可用时只能显式选择以下一种方式，不得猜测模型：

--- a/skills/tampermonkey-cli/SKILL.md
+++ b/skills/tampermonkey-cli/SKILL.md
@@ -41,7 +41,8 @@ python skills/tampermonkey-cli/scripts/tampermonkey.py --help
 ./scripts/tampermonkey.py list
 ./scripts/tampermonkey.py get '<script-path>/source' --output /tmp/example.user.js
 ./scripts/tampermonkey.py put /path/to/example.user.js
-./scripts/tampermonkey.py patch '<script-path>/source' /path/to/example.user.js
+./scripts/tampermonkey.py patch '<script-path>/source' /tmp/example.user.js \
+  && rm -- /tmp/example.user.js
 ```
 
 ## Socket 约定
@@ -69,5 +70,9 @@ python skills/tampermonkey-cli/scripts/tampermonkey.py --help
 - `path` 是 Tampermonkey Editors 返回的内部路径，通常形如 `<script-id>/source`，不要自己猜。
 - `get` 必须指定 `--output`；读取后用 `sed`、`rg`、`diff`、编辑器等常规文件工具查看内容。
 - `put`、`patch` 和 `delete` 会修改浏览器里的 Tampermonkey 脚本；执行前确认目标文件内容是最终版本。
+- 如果 `get` 的输出由 Agent 放在 `/tmp` 中，仅用于当前单次修改，且成功后不再复用，
+  在同一次 shell 调用中把最终 `put` 或 `patch` 与 `rm -- <明确路径>` 用 `&&` 串行执行。
+  写操作失败时保留文件，不要使用 `;` 无条件删除，也不要用变量、通配符或目录作为
+  清理目标。用户提供的 userscript 和仓库源码不得自动清理。
 - 如果 `put` 或 `delete` 返回 `405 Method Not Allowed`，这是 Tampermonkey Editors 端拒绝该 action；先在 Tampermonkey UI 中手动创建脚本，再用 `list` 找到 path，并用 `patch` 覆盖内容。
 - 如果命令提示无法连接 socket，先运行 `serve` 并完成 Tampermonkey Editors 连接。

--- a/skills/ticktick-cli/SKILL.md
+++ b/skills/ticktick-cli/SKILL.md
@@ -70,6 +70,19 @@ cd skills/ticktick-cli
 - 任务标签：创建/更新任务时重复传 `--tag`。
 - 复杂 habit payload：用 `--payload-json` 传 JSON 对象，或传 `@path` 读取文件。
 
+如果 JSON 文件由 Agent 为当前单次写操作临时创建，且成功后不再复用，在同一次 shell
+调用中把写操作与 `rm -- <明确路径>` 用 `&&` 串行执行。写操作失败时保留文件，不要
+使用 `;` 无条件删除，也不要用变量、通配符或目录作为清理目标。用户提供的 JSON 和
+后续更新或校验仍需复用的文件不得自动清理。例如：
+
+```bash
+./scripts/ticktick_cli.py --json task create \
+  --project-id <project-id> \
+  --title "任务标题" \
+  --item-json @/tmp/ticktick-items.json \
+  && rm -- /tmp/ticktick-items.json
+```
+
 ## 数据模型
 
 - Project：任务容器，支持 list / kanban / timeline 等视图。

--- a/upstream-skills.toml
+++ b/upstream-skills.toml
@@ -2,7 +2,7 @@
 name = "grill-me"
 repository = "mattpocock/skills"
 path = "skills/productivity/grilling"
-commit = "bfdaef8e989a5c81160e74bc5043bd434da49cac"
+commit = "86cba45f4244b2545112d13e77ba82eb2bfad325"
 
 [[skills]]
 name = "domain-modeling"


### PR DESCRIPTION
## Why

Agent 使用临时文件传递长文本或结构化参数后，需要额外一次工具调用才能清理文件，增加了不必要的执行轮次。由各 CLI 隐式删除输入文件又会混淆文件所有权，并存在误删可复用内容的风险。

## What

- 统一要求把最终写操作与 `rm -- <明确路径>` 通过 `&&` 放在同一次 shell 调用中，操作失败时保留临时文件。
- 覆盖 GitHub、GitLab、Confluence、Jira、Google Sheets、TickTick、Tampermonkey 和提交信息 YAML 的工作流。
- 明确 dry-run、用户文件、附件、备份、仓库源码及后续复用文件的清理边界。
- 同步 `grill-me` 的上游来源 commit；上游仅调整英文标点，现有中文改编无需改写。
