### PR TITLE
feat(repository-workflow): 正式支持 glob pathspec

### DIFF
--- a/skills/repository-workflow/SKILL.md
+++ b/skills/repository-workflow/SKILL.md
@@ -28,7 +28,7 @@ description: 处理从本地 Git 变更到 GitHub/GitLab 协作发布的完整�
 2. 区分当前任务改动与用户已有改动，只处理当前任务负责的路径。
 3. 不要为了当前任务 stash、restore、reset 或清理无关改动。
 4. 如果同一文件混有无法安全分离的改动，停止提交并说明情况。
-5. 通过提交 YAML 的 `paths` 精确限定提交范围，不要提前修改 index；脚本会自动处理其中的未跟踪文件。
+5. 通过提交 YAML 的 `paths` 精确限定提交范围，不要提前修改 index；每一项按仓库相对的 Git pathspec 解释，支持字面路径、目录、通配符和 `:(glob)` magic。脚本会自动处理匹配到的未跟踪文件。
 
 ## 创建 commit
 
@@ -64,7 +64,7 @@ uv run --script scripts/commit_from_yaml.py \
 
 `--model` 跳过自动探测但仍生成 trailer；`--skip-assisted-by` 同时跳过探测和 trailer。两者互斥，后者只用于确实无法获得模型信息的场景。
 
-4. YAML 的 `paths` 非空时，脚本会自动让其中的未跟踪文件进入 Git 的 intent-to-add 状态，再使用 `git commit --only` 限定提交范围；调用方无需预先 stage。若提交失败，脚本会清理自己创建的 intent-to-add 条目。`paths` 为空时提交当前 index，也可用于已经解决冲突的 merge commit。
+4. YAML 的 `paths` 非空时，脚本会把每一项原样作为 Git pathspec 传给 Git，自动让匹配到的未跟踪文件进入 intent-to-add 状态，再使用 `git commit --only` 限定提交范围；调用方无需预先 stage。通配符由 Git 而不是 shell 展开，YAML 中应使用引号；需要让 `*` 不跨越目录分隔符时，使用 `:(glob)` 与 `**` 明确表达层级。若提交失败，脚本会清理自己创建的 intent-to-add 条目。`paths` 为空时提交当前 index，也可用于已经解决冲突的 merge commit。
 5. 脚本会在提交前后校验正文、breaking 标记和 trailer；任何字段中的字面量 `\\n` 都会失败。提交后仍需回读范围与工作区：
 
 ```bash

--- a/skills/repository-workflow/references/commit-messages.md
+++ b/skills/repository-workflow/references/commit-messages.md
@@ -42,7 +42,8 @@ paths:
 
 - `subject` 必填，必须符合 Conventional Commits。
 - `body`、`trailers`、`paths` 可选；不满足上述正文条件时不要写 `body`。确需正文时，它是自由多行字符串，内部 Markdown 与换行完全由调用方控制。
-- `paths` 必须是仓库相对路径；非空时脚本自动处理其中的未跟踪文件，并使用 `git commit --only`，为空时提交当前 index。
+- `paths` 的每一项都是仓库相对的 Git pathspec，支持字面路径、目录、`*`、`?`、字符集合以及 `:(glob)` 等 Git pathspec magic；非空时脚本自动处理匹配到的未跟踪文件，并使用 `git commit --only`，为空时提交当前 index。
+- pathspec 会原样传给 Git，不经过 shell 展开。包含通配符或 magic 时必须在 YAML 中使用引号；需要可预测的目录层级匹配时优先使用 `:(glob)`，其中 `*` 不匹配 `/`、`**` 可跨越目录。例如 `':(glob)src/**/*.py'` 会匹配 `src` 下各层级的 Python 文件。
 - `trailers` 是 `key` / `value` 结构化列表；key 仅支持字母、数字和连字符，value 必须是非空单行字符串。
 - `Assisted-by` 由脚本生成，禁止放入 `trailers`。
 - 所有字符串都禁止包含字面量 `\\n`；多行正文使用 YAML 的 `|` block scalar 表达。

--- a/skills/repository-workflow/scripts/commit_from_yaml.py
+++ b/skills/repository-workflow/scripts/commit_from_yaml.py
@@ -176,7 +176,7 @@ class CommitSpec(StrictModel):
 
     @model_validator(mode="after")
     def validate_paths(self) -> Self:
-        """限制 paths 为不重复的仓库相对路径。"""
+        """限制 paths 为不重复的仓库相对 Git pathspec。"""
 
         if len(self.paths) != len(set(self.paths)):
             raise ValueError("paths must not contain duplicates")
@@ -367,7 +367,7 @@ def validate_rendered_message(message: str, assisted_by: str | None) -> None:
 
 
 def list_untracked_paths(repo: Path, paths: list[str]) -> list[str]:
-    """返回 paths 范围内尚未进入 index 的文件。"""
+    """返回 pathspec 匹配且尚未进入 index 的文件。"""
 
     output = run_git(
         repo,

--- a/skills/repository-workflow/scripts/tests/test_commit_from_yaml.py
+++ b/skills/repository-workflow/scripts/tests/test_commit_from_yaml.py
@@ -241,6 +241,50 @@ paths:
         self.assertEqual(committed_paths, ["new.txt"])
         self.assertEqual(staged_paths, ["unrelated.txt"])
 
+    def test_commits_tracked_and_untracked_paths_matching_git_glob(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            commit_from_yaml.run_git(repo, ["init", "--quiet"])
+            commit_from_yaml.run_git(repo, ["config", "user.name", "Test User"])
+            commit_from_yaml.run_git(repo, ["config", "user.email", "test@example.com"])
+            tracked = repo / "src" / "tracked.txt"
+            tracked.parent.mkdir()
+            tracked.write_text("base\n", encoding="utf-8")
+            unrelated = repo / "unrelated.txt"
+            unrelated.write_text("base\n", encoding="utf-8")
+            commit_from_yaml.run_git(repo, ["add", "src/tracked.txt", "unrelated.txt"])
+            commit_from_yaml.run_git(repo, ["commit", "-m", "test: initial commit"])
+
+            tracked.write_text("changed\n", encoding="utf-8")
+            untracked = repo / "src" / "nested" / "new.txt"
+            untracked.parent.mkdir()
+            untracked.write_text("new content\n", encoding="utf-8")
+            unrelated.write_text("staged change\n", encoding="utf-8")
+            commit_from_yaml.run_git(repo, ["add", "unrelated.txt"])
+            spec = commit_from_yaml.load_spec(
+                """
+subject: "test(commit): support git glob pathspecs"
+paths:
+  - ":(glob)src/**/*.txt"
+"""
+            )
+            message = commit_from_yaml.render_message(spec, "Codex:gpt-test")
+
+            sha = commit_from_yaml.create_commit(repo, spec, message, "Codex:gpt-test")
+
+            committed_paths = commit_from_yaml.run_git(
+                repo, ["show", "--format=", "--name-only", sha]
+            ).splitlines()
+            staged_paths = commit_from_yaml.run_git(
+                repo, ["diff", "--cached", "--name-only"]
+            ).splitlines()
+
+        self.assertEqual(
+            committed_paths,
+            ["src/nested/new.txt", "src/tracked.txt"],
+        )
+        self.assertEqual(staged_paths, ["unrelated.txt"])
+
     def test_restores_untracked_path_after_commit_failure(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory)


### PR DESCRIPTION
## Why

`commit_from_yaml.py` 已将 `paths` 原样传给 Git，但现有文档只承诺仓库相对路径，glob/pathspec 能力属于未声明行为。

## What

- 明确将 `paths` 定义为仓库相对的 Git pathspec，正式支持通配符和 `:(glob)` magic。
- 说明 pathspec 不经过 shell 展开、YAML 引号要求，以及 `*`/`**` 的目录匹配语义。
- 增加集成测试，覆盖同一 glob 同时提交已跟踪修改和未跟踪文件，并保留无关 staged 改动。
