### PR TITLE
feat(skills): 增加 Telegram 长任务结果通知

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ notification_method = "bel"
 | [`upstream-pr-staging`](skills/upstream-pr-staging/SKILL.md) | 为 GitHub 上游 PR 先创建 fork 内部 draft、低干扰收敛方案与 CI；必要时构造 red/green 回归测试证据链。 |
 | [`ticktick-cli`](skills/ticktick-cli/SKILL.md) | 使用 Python CLI 与 Dida365 Open API 交互以管理滴答清单任务/项目，适用于需要通过脚本或命令行调用滴答清单接口的场景（如项目/任务的查询、创建、更新、完成、删除）。 |
 | [`tampermonkey-cli`](skills/tampermonkey-cli/SKILL.md) | 通过 Tampermonkey Editors 管理浏览器里的 Tampermonkey userscript，支持安装、更新、读取、列出和删除脚本。 |
+| [`notify-via-telegram`](skills/notify-via-telegram/SKILL.md) | 在用户明确订阅后，通过本地安全配置发送当前长任务的最终结果或待处理 Telegram 通知。 |
 
 ## 第三方来源与许可
 

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: notify-via-telegram
+description: 在用户明确要求后，通过本地安全配置发送当前长任务的 Telegram 结果通知；适用于用户希望离开终端，并在任务最终成功、最终失败或等待其处理时收到消息的场景。不得仅因任务耗时较长或一般任务完成而发送。
+---
+
+# Notify via Telegram
+
+把 Telegram 通知视为用户对当前长任务的“结果订阅”，不是一般通知渠道。Bot Token 和目标 Chat ID 保存在用户本地配置文件中，不写入提示词、命令参数或仓库。
+
+## 授权边界
+
+- 只有用户在当前任务中明确要求通过 Telegram 通知，才允许发送。自然语言要求和显式调用本 skill 都可以表达授权。
+- 不要因为任务耗时较长、执行了很多步骤、skill 被自动识别或普通任务完成而推断授权。
+- 授权只覆盖当前任务，不延续到之后的任务。
+- 默认不发送开始、进度、阶段完成、单条命令失败或自动重试消息。
+- 在最终成功、确定无法继续的最终失败或必须等待用户输入时发送。可自动恢复的中间失败不发送。
+- 等待用户处理时发送一次；用户回复并恢复执行后，当前订阅继续有效，任务最终结束时再发送结果。
+- 每个通知事件只尝试发送一次。发送失败后不要自动重试，避免结果不确定时产生重复消息。
+
+## 执行约定
+
+说明：以下脚本调用均以当前 `SKILL.md` 所在文件夹为 workdir。
+
+脚本调用方式（支持 `env -S` 时直接执行；不要用 `uv run python` 或 `python`）：
+
+```bash
+cd skills/notify-via-telegram && ./scripts/notify.py --help
+```
+
+不支持 `env -S` 时使用：
+
+```bash
+cd skills/notify-via-telegram && uv run --script scripts/notify.py --help
+```
+
+Agent 调用时使用 `--json`，并把全局参数放在子命令前。
+
+## 通知格式
+
+只使用以下状态：
+
+- `success`：整个任务最终完成。
+- `failed`：整个任务确定无法完成，而不是某个中间步骤失败。
+- `action-required`：任务暂停，必须等待用户输入或授权。
+
+`title` 和 `summary` 必填；`verification`、`action`、`context` 可选。保持内容简洁，不发送完整日志、堆栈、凭据或冗长本地路径。
+
+发送成功结果：
+
+```bash
+./scripts/notify.py --json send \
+  --status success \
+  --title "任务标题" \
+  --summary "最终结果的一句话摘要" \
+  --verification "关键验证结果" \
+  --context "仓库或任务上下文"
+```
+
+发送失败结果：
+
+```bash
+./scripts/notify.py --json send \
+  --status failed \
+  --title "任务标题" \
+  --summary "无法完成的直接原因" \
+  --action "建议的下一步"
+```
+
+等待用户处理：
+
+```bash
+./scripts/notify.py --json send \
+  --status action-required \
+  --title "任务标题" \
+  --summary "当前状态" \
+  --action "需要用户决定或提供的内容"
+```
+
+在不读取配置、不访问 Telegram 的情况下预览同样的结构化参数：
+
+```bash
+./scripts/notify.py preview \
+  --status success \
+  --title "任务标题" \
+  --summary "最终结果的一句话摘要"
+```
+
+脚本统一生成 Telegram HTML 并转义所有输入字段；不要自行添加 Telegram HTML 或 Markdown 标记。
+
+## 配置
+
+默认配置文件为 `${XDG_CONFIG_HOME:-~/.config}/notify-via-telegram/config.toml`；可用 `NOTIFY_VIA_TELEGRAM_CONFIG` 或全局 `--config` 指定其它文件。
+
+```bash
+./scripts/notify.py config path
+./scripts/notify.py config show
+./scripts/notify.py config get chat-id
+./scripts/notify.py config set chat-id <chat-id>
+./scripts/notify.py config set bot-token
+./scripts/notify.py config unset chat-id
+./scripts/notify.py config check
+```
+
+- `config set bot-token` 需要用户在交互式终端中隐藏输入；不要索取 Token，也不要尝试通过命令行参数传入。
+- `config show`、`config get bot-token` 与所有 JSON 输出都不会回显 Token。
+- `config check` 会访问 Telegram 验证 Bot 与目标 Chat，但不会发送消息。
+- 配置缺失时，告诉用户应执行哪些配置命令；不要替用户猜测 Token 或 Chat ID。
+
+发送成功后读取 JSON 中的 `message_id`。发送失败时，把通知失败与原任务结果分开报告，不要因此改变原任务的最终状态。

--- a/skills/notify-via-telegram/agents/openai.yaml
+++ b/skills/notify-via-telegram/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Notify via Telegram"
+  short_description: "在明确订阅后发送长任务的 Telegram 结果通知"
+  default_prompt: "使用 $notify-via-telegram 在这个长任务有最终结果或需要我处理时发送 Telegram 通知。"

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env -S uv run --script
+#
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "httpx2>=2.12.0",
+#     "pydantic>=2.13.4",
+#     "rich>=15.0.0",
+#     "tomli-w>=1.2.0",
+#     "typer>=0.27.1",
+# ]
+# ///
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import sys
+import tempfile
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, Any
+
+import httpx2
+import tomli_w
+import tomllib
+import typer
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from rich.console import Console
+from rich.table import Table
+
+CONFIG_ENV = "NOTIFY_VIA_TELEGRAM_CONFIG"
+DEFAULT_TIMEOUT_SECONDS = 10.0
+TELEGRAM_API_BASE = "https://api.telegram.org"
+
+app = typer.Typer(no_args_is_help=True, add_completion=False)
+config_app = typer.Typer(
+    no_args_is_help=True, add_completion=False, help="管理本地配置。"
+)
+app.add_typer(config_app, name="config")
+console = Console()
+error_console = Console(stderr=True)
+
+
+class ConfigKey(str, Enum):
+    """CLI 可管理的配置项。"""
+
+    bot_token = "bot-token"
+    chat_id = "chat-id"
+
+
+class NotificationStatus(str, Enum):
+    """长任务通知的结果状态。"""
+
+    success = "success"
+    failed = "failed"
+    action_required = "action-required"
+
+
+class TelegramConfig(BaseModel):
+    """本地 Telegram 配置。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    bot_token: str | None = None
+    chat_id: str | None = None
+
+
+class AppState(BaseModel):
+    """CLI 全局状态。"""
+
+    config_path: Path
+    json_output: bool
+
+
+class Notification(BaseModel):
+    """结构化长任务通知。"""
+
+    status: NotificationStatus
+    title: str = Field(min_length=1, max_length=80)
+    summary: str = Field(min_length=1, max_length=600)
+    verification: str | None = Field(default=None, min_length=1, max_length=200)
+    action: str | None = Field(default=None, min_length=1, max_length=200)
+    context: str | None = Field(default=None, min_length=1, max_length=80)
+
+    @field_validator(
+        "title", "summary", "verification", "action", "context", mode="before"
+    )
+    @classmethod
+    def strip_text(cls, value: object) -> object:
+        """移除字段首尾空白，保持通知紧凑。"""
+
+        return value.strip() if isinstance(value, str) else value
+
+
+STATUS_PRESENTATION = {
+    NotificationStatus.success: ("✅", "任务完成"),
+    NotificationStatus.failed: ("❌", "任务失败"),
+    NotificationStatus.action_required: ("⚠️", "等待你处理"),
+}
+
+
+def notification_from_options(
+    *,
+    status: NotificationStatus,
+    title: str,
+    summary: str,
+    verification: str | None,
+    action: str | None,
+    context: str | None,
+) -> Notification:
+    """校验 CLI 提供的结构化通知字段。"""
+
+    try:
+        return Notification(
+            status=status,
+            title=title,
+            summary=summary,
+            verification=verification,
+            action=action,
+            context=context,
+        )
+    except ValidationError as exc:
+        details = ", ".join(
+            f"{error['loc'][-1]}: {error['msg']}"
+            for error in exc.errors(include_input=False)
+        )
+        abort(f"通知内容无效：{details}")
+
+
+def notification_lines(notification: Notification, *, html_mode: bool) -> list[str]:
+    """生成结构化通知的各行内容。"""
+
+    icon, status_label = STATUS_PRESENTATION[notification.status]
+    escape = html.escape if html_mode else lambda value: value
+    header = f"{icon} Codex · {status_label}"
+    title = escape(notification.title)
+    lines = [
+        f"{icon} <b>Codex · {status_label}</b>" if html_mode else header,
+        f"<b>{title}</b>" if html_mode else notification.title,
+        "",
+        escape(notification.summary),
+    ]
+
+    optional_lines = []
+    if notification.verification:
+        optional_lines.append(f"🧪 验证：{escape(notification.verification)}")
+    if notification.action:
+        optional_lines.append(f"👉 下一步：{escape(notification.action)}")
+    if notification.context:
+        optional_lines.append(f"📦 上下文：{escape(notification.context)}")
+    if optional_lines:
+        lines.extend(["", *optional_lines])
+    return lines
+
+
+def render_notification_html(notification: Notification) -> str:
+    """渲染 Telegram HTML 通知。"""
+
+    return "\n".join(notification_lines(notification, html_mode=True))
+
+
+def render_notification_plain(notification: Notification) -> str:
+    """渲染终端预览使用的纯文本通知。"""
+
+    return "\n".join(notification_lines(notification, html_mode=False))
+
+
+def default_config_path() -> Path:
+    """返回默认配置文件路径。"""
+
+    overridden = os.environ.get(CONFIG_ENV)
+    if overridden:
+        return Path(overridden).expanduser()
+
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return config_home / "notify-via-telegram" / "config.toml"
+
+
+def state_from_context(ctx: typer.Context) -> AppState:
+    """从 Typer 上下文读取全局状态。"""
+
+    if not isinstance(ctx.obj, AppState):
+        raise TypeError("CLI state is not initialized")
+    return ctx.obj
+
+
+def emit(state: AppState, payload: dict[str, Any], message: str) -> None:
+    """按调用方需要输出 JSON 或人类可读文本。"""
+
+    if state.json_output:
+        typer.echo(json.dumps(payload, ensure_ascii=False))
+    else:
+        console.print(message)
+
+
+def abort(message: str) -> None:
+    """输出安全错误并以非零状态退出。"""
+
+    error_console.print(f"[red]错误：[/red]{message}")
+    raise typer.Exit(1)
+
+
+def load_config(path: Path, *, allow_missing: bool = False) -> TelegramConfig:
+    """读取并校验本地配置。"""
+
+    if not path.exists():
+        if allow_missing:
+            return TelegramConfig()
+        abort(f"配置文件不存在：{path}；请先运行 config set。")
+
+    try:
+        with path.open("rb") as config_file:
+            raw_config = tomllib.load(config_file)
+        return TelegramConfig.model_validate(raw_config)
+    except (OSError, tomllib.TOMLDecodeError):
+        abort(f"无法读取配置文件：{path}")
+    except ValidationError:
+        abort("配置内容无效；请检查是否只包含 bot_token 和 chat_id。")
+
+
+def write_config(path: Path, config: TelegramConfig) -> None:
+    """以仅当前用户可读写的权限原子更新配置。"""
+
+    temp_path: Path | None = None
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        content = tomli_w.dumps(config.model_dump(exclude_none=True)).encode()
+        with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as temp_file:
+            temp_path = Path(temp_file.name)
+            os.chmod(temp_path, 0o600)
+            temp_file.write(content)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+        os.chmod(path, 0o600)
+    except OSError:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+        abort(f"无法写入配置文件：{path}")
+
+
+def complete_config(path: Path) -> TelegramConfig:
+    """读取可用于 Telegram API 的完整配置。"""
+
+    config = load_config(path)
+    missing = [
+        name
+        for name, value in (
+            ("bot-token", config.bot_token),
+            ("chat-id", config.chat_id),
+        )
+        if not value
+    ]
+    if missing:
+        abort(f"缺少配置项：{', '.join(missing)}")
+    return config
+
+
+def telegram_call(
+    config: TelegramConfig, method: str, payload: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """执行一次 Telegram Bot API 请求且不泄露 Token。"""
+
+    url = f"{TELEGRAM_API_BASE}/bot{config.bot_token}/{method}"
+    try:
+        with httpx2.Client(timeout=DEFAULT_TIMEOUT_SECONDS) as client:
+            response = client.post(url, json=payload or {})
+    except httpx2.RequestError as exc:
+        abort(f"Telegram 请求失败（{type(exc).__name__}）。")
+
+    try:
+        response_data = response.json()
+    except ValueError:
+        abort(f"Telegram 返回了无法解析的响应（HTTP {response.status_code}）。")
+
+    if not isinstance(response_data, dict):
+        abort(f"Telegram 返回了结构异常的响应（HTTP {response.status_code}）。")
+
+    if response.status_code >= 400 or not response_data.get("ok"):
+        description = response_data.get("description")
+        detail = description if isinstance(description, str) else "未知 API 错误"
+        abort(f"Telegram API 拒绝请求（HTTP {response.status_code}）：{detail}")
+
+    result = response_data.get("result")
+    if not isinstance(result, dict):
+        abort("Telegram 返回的数据缺少 result 对象。")
+    return result
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", help=f"配置文件路径；也可使用 {CONFIG_ENV}。"),
+    ] = None,
+    json_output: Annotated[
+        bool, typer.Option("--json", help="输出适合 Agent 解析的 JSON。")
+    ] = False,
+) -> None:
+    """通过本地安全配置发送 Telegram 通知。"""
+
+    ctx.obj = AppState(
+        config_path=(config.expanduser() if config else default_config_path()),
+        json_output=json_output,
+    )
+
+
+@app.command("send")
+def send_message(
+    ctx: typer.Context,
+    status: Annotated[
+        NotificationStatus, typer.Option("--status", help="长任务的最终状态。")
+    ],
+    title: Annotated[str, typer.Option("--title", help="用于识别任务的简短标题。")],
+    summary: Annotated[str, typer.Option("--summary", help="任务结果的一句话摘要。")],
+    verification: Annotated[
+        str | None, typer.Option("--verification", help="可选的验证结果。")
+    ] = None,
+    action: Annotated[
+        str | None, typer.Option("--action", help="可选的下一步或所需操作。")
+    ] = None,
+    context: Annotated[
+        str | None, typer.Option("--context", help="可选的仓库或任务上下文。")
+    ] = None,
+) -> None:
+    """发送一条结构化长任务结果通知。"""
+
+    state = state_from_context(ctx)
+    notification = notification_from_options(
+        status=status,
+        title=title,
+        summary=summary,
+        verification=verification,
+        action=action,
+        context=context,
+    )
+    config = complete_config(state.config_path)
+    result = telegram_call(
+        config,
+        "sendMessage",
+        {
+            "chat_id": config.chat_id,
+            "text": render_notification_html(notification),
+            "parse_mode": "HTML",
+        },
+    )
+    emit(
+        state,
+        {
+            "ok": True,
+            "status": notification.status.value,
+            "message_id": result.get("message_id"),
+        },
+        f"[green]通知已发送[/green]（message_id={result.get('message_id')}）。",
+    )
+
+
+@app.command("preview")
+def preview_message(
+    ctx: typer.Context,
+    status: Annotated[
+        NotificationStatus, typer.Option("--status", help="长任务的最终状态。")
+    ],
+    title: Annotated[str, typer.Option("--title", help="用于识别任务的简短标题。")],
+    summary: Annotated[str, typer.Option("--summary", help="任务结果的一句话摘要。")],
+    verification: Annotated[
+        str | None, typer.Option("--verification", help="可选的验证结果。")
+    ] = None,
+    action: Annotated[
+        str | None, typer.Option("--action", help="可选的下一步或所需操作。")
+    ] = None,
+    context: Annotated[
+        str | None, typer.Option("--context", help="可选的仓库或任务上下文。")
+    ] = None,
+) -> None:
+    """在本地预览通知，不读取配置或访问 Telegram。"""
+
+    state = state_from_context(ctx)
+    notification = notification_from_options(
+        status=status,
+        title=title,
+        summary=summary,
+        verification=verification,
+        action=action,
+        context=context,
+    )
+    if state.json_output:
+        emit(
+            state,
+            {
+                "status": notification.status.value,
+                "text": render_notification_html(notification),
+                "parse_mode": "HTML",
+            },
+            "",
+        )
+        return
+    console.print(render_notification_plain(notification), markup=False)
+
+
+@config_app.command("path")
+def show_config_path(ctx: typer.Context) -> None:
+    """显示当前配置文件路径。"""
+
+    state = state_from_context(ctx)
+    emit(
+        state,
+        {"config_path": str(state.config_path)},
+        str(state.config_path),
+    )
+
+
+@config_app.command("show")
+def show_config(ctx: typer.Context) -> None:
+    """显示配置，Bot Token 始终脱敏。"""
+
+    state = state_from_context(ctx)
+    config = load_config(state.config_path, allow_missing=True)
+    payload = {
+        "config_path": str(state.config_path),
+        "bot_token": "configured" if config.bot_token else None,
+        "chat_id": config.chat_id,
+    }
+    if state.json_output:
+        emit(state, payload, "")
+        return
+
+    table = Table(title="Telegram 通知配置")
+    table.add_column("配置项")
+    table.add_column("值")
+    table.add_row("config_path", str(state.config_path))
+    table.add_row("bot_token", "<已配置>" if config.bot_token else "<未配置>")
+    table.add_row("chat_id", config.chat_id or "<未配置>")
+    console.print(table)
+
+
+@config_app.command("get")
+def get_config(
+    ctx: typer.Context,
+    key: Annotated[ConfigKey, typer.Argument(help="要查看的配置项。")],
+) -> None:
+    """查看单个配置项，Bot Token 始终脱敏。"""
+
+    state = state_from_context(ctx)
+    config = load_config(state.config_path, allow_missing=True)
+    if key is ConfigKey.bot_token:
+        value = "configured" if config.bot_token else None
+    else:
+        value = config.chat_id
+    emit(state, {"key": key.value, "value": value}, str(value or "<未配置>"))
+
+
+@config_app.command("set", context_settings={"ignore_unknown_options": True})
+def set_config(
+    ctx: typer.Context,
+    key: Annotated[ConfigKey, typer.Argument(help="要设置的配置项。")],
+    value: Annotated[
+        str | None,
+        typer.Argument(help="配置值；设置 bot-token 时必须省略并交互输入。"),
+    ] = None,
+) -> None:
+    """设置配置项；Bot Token 只接受隐藏的交互式输入。"""
+
+    state = state_from_context(ctx)
+    config = load_config(state.config_path, allow_missing=True)
+
+    if key is ConfigKey.bot_token:
+        if value is not None:
+            abort("bot-token 不接受命令行参数；请省略值并通过隐藏提示输入。")
+        if not sys.stdin.isatty():
+            abort("设置 bot-token 需要交互式终端。")
+        new_value = typer.prompt("Bot Token", hide_input=True).strip()
+        if not new_value:
+            abort("bot-token 不能为空。")
+        config.bot_token = new_value
+    else:
+        new_value = value.strip() if value is not None else ""
+        if not new_value:
+            abort("chat-id 不能为空。")
+        config.chat_id = new_value
+
+    write_config(state.config_path, config)
+    emit(
+        state,
+        {"ok": True, "key": key.value, "config_path": str(state.config_path)},
+        f"[green]已更新[/green] {key.value}。",
+    )
+
+
+@config_app.command("unset")
+def unset_config(
+    ctx: typer.Context,
+    key: Annotated[ConfigKey, typer.Argument(help="要删除的配置项。")],
+) -> None:
+    """删除一个配置项。"""
+
+    state = state_from_context(ctx)
+    config = load_config(state.config_path, allow_missing=True)
+    if key is ConfigKey.bot_token:
+        config.bot_token = None
+    else:
+        config.chat_id = None
+    write_config(state.config_path, config)
+    emit(
+        state,
+        {"ok": True, "key": key.value, "config_path": str(state.config_path)},
+        f"[green]已删除[/green] {key.value}。",
+    )
+
+
+@config_app.command("check")
+def check_config(ctx: typer.Context) -> None:
+    """校验 Bot 与目标会话，但不发送消息。"""
+
+    state = state_from_context(ctx)
+    config = complete_config(state.config_path)
+    bot = telegram_call(config, "getMe")
+    chat = telegram_call(config, "getChat", {"chat_id": config.chat_id})
+    payload = {
+        "ok": True,
+        "bot_username": bot.get("username"),
+        "chat_id": str(chat.get("id")),
+        "chat_type": chat.get("type"),
+        "chat_title": chat.get("title") or chat.get("username"),
+    }
+    emit(
+        state,
+        payload,
+        "[green]配置有效[/green]："
+        f"@{bot.get('username')} -> {payload['chat_title'] or payload['chat_id']}",
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib.util
+import secrets
+import sys
+from pathlib import Path
+
+import pytest
+import tomllib
+from typer.testing import CliRunner
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "notify.py"
+SPEC = importlib.util.spec_from_file_location("notify_via_telegram", SCRIPT_PATH)
+assert SPEC is not None
+notify = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = notify
+SPEC.loader.exec_module(notify)
+
+
+def test_config_set_accepts_negative_chat_id(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    chat_id = f"-{secrets.randbelow(9_000_000_000) + 1_000_000_000}"
+
+    result = CliRunner().invoke(
+        notify.app,
+        [
+            "--config",
+            str(config_path),
+            "config",
+            "set",
+            "chat-id",
+            chat_id,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    with config_path.open("rb") as config_file:
+        assert tomllib.load(config_file)["chat_id"] == chat_id
+
+
+@pytest.mark.parametrize(
+    ("status", "header"),
+    [
+        ("success", "✅ <b>Codex · 任务完成</b>"),
+        ("failed", "❌ <b>Codex · 任务失败</b>"),
+        ("action-required", "⚠️ <b>Codex · 等待你处理</b>"),
+    ],
+)
+def test_render_notification_html_uses_status_header_and_escapes_fields(
+    status: str, header: str
+) -> None:
+    notification = notify.Notification(
+        status=status,
+        title="修复 <Chat ID>",
+        summary="A & B",
+        verification="157 > 0",
+        action="重新执行",
+        context="prompts",
+    )
+
+    assert (
+        notify.render_notification_html(notification)
+        == f"""{header}
+<b>修复 &lt;Chat ID&gt;</b>
+
+A &amp; B
+
+🧪 验证：157 &gt; 0
+👉 下一步：重新执行
+📦 上下文：prompts"""
+    )
+
+
+def test_send_uses_structured_html_payload(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        notify,
+        "complete_config",
+        lambda _path: notify.TelegramConfig(
+            bot_token="test-token", chat_id="test-chat"
+        ),
+    )
+
+    def fake_telegram_call(config, method, payload):
+        captured.update(config=config, method=method, payload=payload)
+        return {"message_id": 42}
+
+    monkeypatch.setattr(notify, "telegram_call", fake_telegram_call)
+
+    result = CliRunner().invoke(
+        notify.app,
+        [
+            "--config",
+            str(tmp_path / "config.toml"),
+            "--json",
+            "send",
+            "--status",
+            "success",
+            "--title",
+            "长任务完成",
+            "--summary",
+            "所有步骤已经完成。",
+            "--verification",
+            "157 项测试通过",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "sendMessage"
+    assert captured["payload"] == {
+        "chat_id": "test-chat",
+        "text": """✅ <b>Codex · 任务完成</b>
+<b>长任务完成</b>
+
+所有步骤已经完成。
+
+🧪 验证：157 项测试通过""",
+        "parse_mode": "HTML",
+    }
+
+
+def test_preview_does_not_access_telegram(monkeypatch) -> None:
+    def unexpected_telegram_call(*_args, **_kwargs):
+        raise AssertionError("preview must not access Telegram")
+
+    monkeypatch.setattr(notify, "telegram_call", unexpected_telegram_call)
+
+    result = CliRunner().invoke(
+        notify.app,
+        [
+            "preview",
+            "--status",
+            "failed",
+            "--title",
+            "长任务未完成",
+            "--summary",
+            "构建失败。",
+            "--action",
+            "检查构建日志",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "❌ Codex · 任务失败" in result.output
+    assert "👉 下一步：检查构建日志" in result.output


### PR DESCRIPTION
## Why

长任务执行期间，用户需要在离开终端后及时获知最终结果或待处理事项，同时避免普通任务和中间状态产生通知噪音。

## What

- 新增 `notify-via-telegram` skill，把通知限定为用户对当前任务的显式结果订阅，并区分成功、失败和等待处理三种状态。
- 提供基于本地安全配置的 PEP 723 CLI，支持配置管理、结构化 Telegram HTML 通知、Token 脱敏和单次发送。
- 支持不读取配置、不访问 Telegram 的本地预览，并覆盖负数 Chat ID、HTML 转义和结构化发送等行为。
