### PR TITLE
feat(skills)!: 使用 Telegram Rich Message 优化结果通知

### DIFF
--- a/skills/dcjanus-preferences/SKILL.md
+++ b/skills/dcjanus-preferences/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dcjanus-preferences
-description: 记录 DCjanus 的跨语言技术选型偏好以及 Python/Rust/Go 第三方库偏好，供 AI 在存储、分析、压缩、归档、引入依赖或替换库时优先参考。适用于技术方案对比或需要遵循 DCjanus 个人偏好进行开发的场景。
+description: 记录 DCjanus 的跨语言技术选型、API 能力选择以及 Python/Rust/Go 第三方库偏好，供 AI 在存储、分析、压缩、归档、消息呈现、引入依赖或替换库时优先参考。适用于技术方案对比或需要遵循 DCjanus 个人偏好进行开发的场景。
 ---
 
 ## Usage
 
-- 先确认选型问题是否跨语言：数据库、分析、压缩或归档场景读取 `references/data-storage.md`；语言生态库选择则读取对应语言参考文件。
+- 先确认选型问题是否跨语言：数据库、分析、压缩或归档场景读取 `references/data-storage.md`；Telegram Bot 消息能力选择读取 `references/telegram-bot-api.md`；语言生态库选择则读取对应语言参考文件。
 - 引入或替换第三方库时优先使用偏好清单。
 - 当工作负载同时具有多种特征、偏好清单未覆盖或与明确需求冲突时，先说明主要工作负载、取舍与建议；结论仍不明确时再向用户确认。
 - 新增语言时创建 `references/<language>.md`；新增跨语言主题时创建聚焦该主题的 reference，避免将无关偏好堆入泛化的 general 文件。
@@ -19,6 +19,7 @@ description: 记录 DCjanus 的跨语言技术选型偏好以及 Python/Rust/Go 
 ## References
 
 - 跨语言数据存储、分析、压缩与归档：`references/data-storage.md`
+- Telegram Bot API 消息能力选择：`references/telegram-bot-api.md`
 - Python: `references/python.md`
 - Rust: `references/rust.md`
 - Go: `references/go.md`

--- a/skills/dcjanus-preferences/references/telegram-bot-api.md
+++ b/skills/dcjanus-preferences/references/telegram-bot-api.md
@@ -1,0 +1,30 @@
+# Telegram Bot API 消息能力选择偏好
+
+## 默认决策
+
+- 短文本、操作确认、简单聊天流程，以及只需要粗体、斜体、链接、代码等少量行内格式时，默认使用 `sendMessage`。它更轻量、实现和调试成本更低，也支持 partial quote 与跨聊天引用等 Rich Message 没有的交互能力。
+- 报告、AI 生成结果、文档片段，或内容需要标题、段落、分隔线、列表、表格、引用、折叠区、公式、媒体等明确块级结构时，使用 `sendRichMessage`。
+- 不因为 `sendRichMessage` 更新、能力更多就默认替换 `sendMessage`。只有 richer structure 能实质提升信息层级、可扫读性或内容表达时才承担更高的 payload 与兼容成本。
+
+## 内容表达方式
+
+- 结构由程序生成、字段中包含用户或外部输入，或 payload schema 需要稳定可测试时，优先使用 `InputRichMessage.blocks`。动态文本作为纯 `RichText` 值传递，不拼接 Markdown/HTML，从而避免转义错误并让块级层级显式可见。
+- 内容本身由可信模板或文档源维护、采用标记语言明显更易读时，可使用 Rich Markdown 或 Rich HTML。`InputRichMessage` 的 `blocks`、`markdown`、`html` 必须且只能选择一个；使用 Markdown/HTML 时仍要正确转义动态内容。
+- 传统 `sendMessage` 的格式化沿用项目现有约定，在 MarkdownV2 与 HTML 中选择一种；不要为了少量样式引入 Rich Message。
+
+## 流式输出与最终消息
+
+- 只有需要在 Telegram 内实时展示生成过程时才使用 `sendMessageDraft` 或 `sendRichMessageDraft`。draft 是临时预览，最终仍必须调用对应的 `sendMessage` 或 `sendRichMessage` 才会持久化。
+- 后台任务的完成通知、异步告警和一次性结果推送默认直接发送最终消息，不使用 draft。
+
+## 兼容性与约束
+
+- 使用前核对目标 Bot API 服务和 SDK 是否支持所需方法及字段；自建 Bot API Server、代理或第三方 SDK 可能落后于 Telegram 云端版本。没有明确兼容需求时，不额外实现 `sendRichMessage` 到 `sendMessage` 的静默回退。
+- Rich Message 当前上限包括 32768 个 UTF-8 字符、500 个块、16 层嵌套与 50 个媒体附件。接近限制时应先压缩内容或拆分消息，不把 Telegram 当作完整日志传输通道。
+- `sendRichMessageDraft` 只用于流式 rich content；`thinking` block 不能放入最终 `sendRichMessage`。
+
+## 官方文档
+
+- [Bot Features: Rich Messages 与 Regular Messages](https://core.telegram.org/bots/features#advanced-formatting-options)
+- [Bot API: InputRichMessage](https://core.telegram.org/bots/api#inputrichmessage)
+- [Bot API: sendRichMessage](https://core.telegram.org/bots/api#sendrichmessage)

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -9,7 +9,7 @@ description: 在用户明确要求后，通过本地安全配置发送当前长�
 
 ## 授权边界
 
-- 只有用户在当前任务中明确要求通过 Telegram 通知，才允许发送。自然语言要求和显式调用本 skill 都可以表达授权。
+- 只有用户在当前任务中显式调用 `$notify-via-telegram` 并要求通过 Telegram 通知，才允许发送。
 - 不要因为任务耗时较长、执行了很多步骤、skill 被自动识别或普通任务完成而推断授权。
 - 授权只覆盖当前任务，不延续到之后的任务。
 - 默认不发送开始、进度、阶段完成、单条命令失败或自动重试消息。
@@ -85,7 +85,9 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram HTML 并转义所有输入字段；不要自行添加 Telegram HTML 或 Markdown 标记。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`，用标题、状态、摘要、下一步和页脚建立视觉层级。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+
+`preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 
 ## 配置
 

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -85,7 +85,7 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram Rich Message 的显式 `blocks`：状态只用 `✅`、`❌`、`⚠️` 区分，并与任务名称组成主标题；摘要以“结果：”标签开头，之后才是下一步和页脚。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`，但不使用 heading：第一行以 `✅`、`❌`、`⚠️` 区分状态并显示粗体“标题”标签，第二行显示粗体“正文”标签；之后才是下一步和页脚。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
 
 `preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -85,7 +85,7 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram Rich Message 的显式 `blocks`，按状态、任务标题、摘要、下一步和页脚的顺序建立视觉层级。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`：来源与状态使用主标题，任务名称使用较小的独立标题，摘要以“结果：”标签开头，之后才是下一步和页脚。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
 
 `preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -85,7 +85,7 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram Rich Message 的显式 `blocks`，用标题、状态、摘要、下一步和页脚建立视觉层级。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`，按状态、任务标题、摘要、下一步和页脚的顺序建立视觉层级。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
 
 `preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -85,7 +85,7 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram Rich Message 的显式 `blocks`：来源与状态使用主标题，任务名称使用较小的独立标题，摘要以“结果：”标签开头，之后才是下一步和页脚。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`：状态只用 `✅`、`❌`、`⚠️` 区分，并与任务名称组成主标题；摘要以“结果：”标签开头，之后才是下一步和页脚。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
 
 `preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -85,7 +85,7 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram Rich Message 的显式 `blocks`：标题和正文各占一个段落，依靠段落留白形成主内容层级；分隔线以下的 footer 统一显示状态、下一步、验证和上下文。`✅`、`❌`、`⚠️` 只作为 footer 中的状态值，不放在主内容行首。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`：任务标题使用小号 heading，最终结论放入 blockquote；仅在提供 `action` 时增加高亮的“需要你处理”段落；最后用单行 footer 紧凑显示状态、验证和上下文。不要添加泛化通知标题、分隔线或逐字段 Emoji。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
 
 `preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -85,7 +85,7 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram Rich Message 的显式 `blocks`，但不使用 heading：第一行以 `✅`、`❌`、`⚠️` 区分状态并显示粗体“标题”标签，第二行显示粗体“正文”标签；之后才是下一步和页脚。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`：标题和正文各占一个段落，依靠段落留白形成主内容层级；分隔线以下的 footer 统一显示状态、下一步、验证和上下文。`✅`、`❌`、`⚠️` 只作为 footer 中的状态值，不放在主内容行首。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
 
 `preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 

--- a/skills/notify-via-telegram/agents/openai.yaml
+++ b/skills/notify-via-telegram/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "Notify via Telegram"
   short_description: "在明确订阅后发送长任务的 Telegram 结果通知"
   default_prompt: "使用 $notify-via-telegram 在这个长任务有最终结果或需要我处理时发送 Telegram 通知。"
+policy:
+  allow_implicit_invocation: false

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -93,10 +93,10 @@ class Notification(BaseModel):
         return value.strip() if isinstance(value, str) else value
 
 
-STATUS_PRESENTATION = {
-    NotificationStatus.success: ("✅", "任务完成"),
-    NotificationStatus.failed: ("❌", "任务失败"),
-    NotificationStatus.action_required: ("⚠️", "等待你处理"),
+STATUS_ICON = {
+    NotificationStatus.success: "✅",
+    NotificationStatus.failed: "❌",
+    NotificationStatus.action_required: "⚠️",
 }
 
 
@@ -131,17 +131,12 @@ def notification_from_options(
 def render_notification_blocks(notification: Notification) -> list[dict[str, Any]]:
     """生成 Telegram Rich Message 的显式内容块。"""
 
-    icon, status_label = STATUS_PRESENTATION[notification.status]
+    icon = STATUS_ICON[notification.status]
     blocks: list[dict[str, Any]] = [
         {
             "type": "heading",
-            "text": f"{icon} Codex · {status_label}",
+            "text": f"{icon} {notification.title}",
             "size": 3,
-        },
-        {
-            "type": "heading",
-            "text": notification.title,
-            "size": 4,
         },
         {
             "type": "paragraph",
@@ -196,10 +191,9 @@ def render_notification_blocks(notification: Notification) -> list[dict[str, Any
 def render_notification_plain(notification: Notification) -> str:
     """渲染终端预览使用的纯文本通知。"""
 
-    icon, status_label = STATUS_PRESENTATION[notification.status]
+    icon = STATUS_ICON[notification.status]
     lines = [
-        f"{icon} Codex · {status_label}",
-        notification.title,
+        f"{icon} {notification.title}",
         "",
         f"结果：{notification.summary}",
     ]

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -135,17 +135,17 @@ def render_notification_blocks(notification: Notification) -> list[dict[str, Any
     blocks: list[dict[str, Any]] = [
         {
             "type": "heading",
-            "text": f"{icon} {notification.title}",
+            "text": f"{icon} {status_label}",
             "size": 3,
         },
         {
             "type": "paragraph",
-            "text": [{"type": "bold", "text": status_label}, " · Codex"],
+            "text": [
+                {"type": "bold", "text": notification.title},
+                " · Codex",
+            ],
         },
-        {
-            "type": "blockquote",
-            "blocks": [{"type": "paragraph", "text": notification.summary}],
-        },
+        {"type": "paragraph", "text": notification.summary},
     ]
 
     if notification.action:
@@ -194,10 +194,10 @@ def render_notification_plain(notification: Notification) -> str:
 
     icon, status_label = STATUS_PRESENTATION[notification.status]
     lines = [
-        f"{icon} {notification.title}",
-        f"{status_label} · Codex",
+        f"{icon} {status_label}",
+        f"{notification.title} · Codex",
         "",
-        f"> {notification.summary}",
+        notification.summary,
     ]
     if notification.action:
         lines.extend(["", f"👉 下一步：{notification.action}"])

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -134,15 +134,18 @@ def render_notification_blocks(notification: Notification) -> list[dict[str, Any
     icon = STATUS_ICON[notification.status]
     blocks: list[dict[str, Any]] = [
         {
-            "type": "heading",
-            "text": f"{icon} {notification.title}",
-            "size": 3,
+            "type": "paragraph",
+            "text": [
+                f"{icon} ",
+                {"type": "bold", "text": "标题"},
+                f"：{notification.title}",
+            ],
         },
         {
             "type": "paragraph",
             "text": [
-                {"type": "bold", "text": "结果："},
-                notification.summary,
+                {"type": "bold", "text": "正文"},
+                f"：{notification.summary}",
             ],
         },
     ]
@@ -193,9 +196,8 @@ def render_notification_plain(notification: Notification) -> str:
 
     icon = STATUS_ICON[notification.status]
     lines = [
-        f"{icon} {notification.title}",
-        "",
-        f"结果：{notification.summary}",
+        f"{icon} 标题：{notification.title}",
+        f"正文：{notification.summary}",
     ]
     if notification.action:
         lines.extend(["", f"👉 下一步：{notification.action}"])

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -135,59 +135,23 @@ def render_notification_blocks(notification: Notification) -> list[dict[str, Any
     blocks: list[dict[str, Any]] = [
         {
             "type": "paragraph",
-            "text": [
-                f"{icon} ",
-                {"type": "bold", "text": "标题"},
-                f"：{notification.title}",
-            ],
+            "text": notification.title,
         },
         {
             "type": "paragraph",
-            "text": [
-                {"type": "bold", "text": "正文"},
-                f"：{notification.summary}",
-            ],
+            "text": notification.summary,
         },
+        {"type": "divider"},
     ]
 
+    footer: list[Any] = [f"状态：{icon}"]
     if notification.action:
-        blocks.append(
-            {
-                "type": "paragraph",
-                "text": [
-                    "👉 ",
-                    {"type": "bold", "text": "下一步："},
-                    notification.action,
-                ],
-            }
-        )
-
-    footer: list[Any] = []
+        footer.extend(["\n", f"下一步：{notification.action}"])
     if notification.verification:
-        footer.extend(
-            [
-                "🧪 ",
-                {"type": "bold", "text": "验证"},
-                f"：{notification.verification}",
-            ]
-        )
+        footer.extend(["\n", f"验证：{notification.verification}"])
     if notification.context:
-        if footer:
-            footer.append("\n")
-        footer.extend(
-            [
-                "📦 ",
-                {"type": "bold", "text": "上下文"},
-                f"：{notification.context}",
-            ]
-        )
-    if footer:
-        blocks.extend(
-            [
-                {"type": "divider"},
-                {"type": "footer", "text": footer},
-            ]
-        )
+        footer.extend(["\n", f"上下文：{notification.context}"])
+    blocks.append({"type": "footer", "text": footer})
     return blocks
 
 
@@ -196,19 +160,19 @@ def render_notification_plain(notification: Notification) -> str:
 
     icon = STATUS_ICON[notification.status]
     lines = [
-        f"{icon} 标题：{notification.title}",
-        f"正文：{notification.summary}",
+        notification.title,
+        "",
+        notification.summary,
+        "",
+        "────────",
+        f"状态：{icon}",
     ]
     if notification.action:
-        lines.extend(["", f"👉 下一步：{notification.action}"])
-
-    footer = []
+        lines.append(f"下一步：{notification.action}")
     if notification.verification:
-        footer.append(f"🧪 验证：{notification.verification}")
+        lines.append(f"验证：{notification.verification}")
     if notification.context:
-        footer.append(f"📦 上下文：{notification.context}")
-    if footer:
-        lines.extend(["", *footer])
+        lines.append(f"上下文：{notification.context}")
     return "\n".join(lines)
 
 

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -13,7 +13,6 @@
 
 from __future__ import annotations
 
-import html
 import json
 import os
 import sys
@@ -129,42 +128,88 @@ def notification_from_options(
         abort(f"通知内容无效：{details}")
 
 
-def notification_lines(notification: Notification, *, html_mode: bool) -> list[str]:
-    """生成结构化通知的各行内容。"""
+def render_notification_blocks(notification: Notification) -> list[dict[str, Any]]:
+    """生成 Telegram Rich Message 的显式内容块。"""
 
     icon, status_label = STATUS_PRESENTATION[notification.status]
-    escape = html.escape if html_mode else lambda value: value
-    header = f"{icon} Codex · {status_label}"
-    title = escape(notification.title)
-    lines = [
-        f"{icon} <b>Codex · {status_label}</b>" if html_mode else header,
-        f"<b>{title}</b>" if html_mode else notification.title,
-        "",
-        escape(notification.summary),
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "heading",
+            "text": f"{icon} {notification.title}",
+            "size": 3,
+        },
+        {
+            "type": "paragraph",
+            "text": [{"type": "bold", "text": status_label}, " · Codex"],
+        },
+        {
+            "type": "blockquote",
+            "blocks": [{"type": "paragraph", "text": notification.summary}],
+        },
     ]
 
-    optional_lines = []
-    if notification.verification:
-        optional_lines.append(f"🧪 验证：{escape(notification.verification)}")
     if notification.action:
-        optional_lines.append(f"👉 下一步：{escape(notification.action)}")
+        blocks.append(
+            {
+                "type": "paragraph",
+                "text": [
+                    "👉 ",
+                    {"type": "bold", "text": "下一步："},
+                    notification.action,
+                ],
+            }
+        )
+
+    footer: list[Any] = []
+    if notification.verification:
+        footer.extend(
+            [
+                "🧪 ",
+                {"type": "bold", "text": "验证"},
+                f"：{notification.verification}",
+            ]
+        )
     if notification.context:
-        optional_lines.append(f"📦 上下文：{escape(notification.context)}")
-    if optional_lines:
-        lines.extend(["", *optional_lines])
-    return lines
-
-
-def render_notification_html(notification: Notification) -> str:
-    """渲染 Telegram HTML 通知。"""
-
-    return "\n".join(notification_lines(notification, html_mode=True))
+        if footer:
+            footer.append("\n")
+        footer.extend(
+            [
+                "📦 ",
+                {"type": "bold", "text": "上下文"},
+                f"：{notification.context}",
+            ]
+        )
+    if footer:
+        blocks.extend(
+            [
+                {"type": "divider"},
+                {"type": "footer", "text": footer},
+            ]
+        )
+    return blocks
 
 
 def render_notification_plain(notification: Notification) -> str:
     """渲染终端预览使用的纯文本通知。"""
 
-    return "\n".join(notification_lines(notification, html_mode=False))
+    icon, status_label = STATUS_PRESENTATION[notification.status]
+    lines = [
+        f"{icon} {notification.title}",
+        f"{status_label} · Codex",
+        "",
+        f"> {notification.summary}",
+    ]
+    if notification.action:
+        lines.extend(["", f"👉 下一步：{notification.action}"])
+
+    footer = []
+    if notification.verification:
+        footer.append(f"🧪 验证：{notification.verification}")
+    if notification.context:
+        footer.append(f"📦 上下文：{notification.context}")
+    if footer:
+        lines.extend(["", *footer])
+    return "\n".join(lines)
 
 
 def default_config_path() -> Path:
@@ -340,11 +385,12 @@ def send_message(
     config = complete_config(state.config_path)
     result = telegram_call(
         config,
-        "sendMessage",
+        "sendRichMessage",
         {
             "chat_id": config.chat_id,
-            "text": render_notification_html(notification),
-            "parse_mode": "HTML",
+            "rich_message": {
+                "blocks": render_notification_blocks(notification),
+            },
         },
     )
     emit(
@@ -392,8 +438,9 @@ def preview_message(
             state,
             {
                 "status": notification.status.value,
-                "text": render_notification_html(notification),
-                "parse_mode": "HTML",
+                "rich_message": {
+                    "blocks": render_notification_blocks(notification),
+                },
             },
             "",
         )

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -93,10 +93,10 @@ class Notification(BaseModel):
         return value.strip() if isinstance(value, str) else value
 
 
-STATUS_ICON = {
-    NotificationStatus.success: "✅",
-    NotificationStatus.failed: "❌",
-    NotificationStatus.action_required: "⚠️",
+STATUS_PRESENTATION = {
+    NotificationStatus.success: ("✅", "已完成"),
+    NotificationStatus.failed: ("❌", "未完成"),
+    NotificationStatus.action_required: ("⚠️", "等待处理"),
 }
 
 
@@ -131,26 +131,35 @@ def notification_from_options(
 def render_notification_blocks(notification: Notification) -> list[dict[str, Any]]:
     """生成 Telegram Rich Message 的显式内容块。"""
 
-    icon = STATUS_ICON[notification.status]
+    icon, status_label = STATUS_PRESENTATION[notification.status]
     blocks: list[dict[str, Any]] = [
         {
-            "type": "paragraph",
+            "type": "heading",
             "text": notification.title,
+            "size": 4,
         },
         {
-            "type": "paragraph",
-            "text": notification.summary,
+            "type": "blockquote",
+            "blocks": [{"type": "paragraph", "text": notification.summary}],
         },
-        {"type": "divider"},
     ]
 
-    footer: list[Any] = [f"状态：{icon}"]
     if notification.action:
-        footer.extend(["\n", f"下一步：{notification.action}"])
+        blocks.append(
+            {
+                "type": "paragraph",
+                "text": [
+                    {"type": "marked", "text": "需要你处理"},
+                    f"：{notification.action}",
+                ],
+            }
+        )
+
+    footer: list[Any] = [f"{icon} {status_label}"]
     if notification.verification:
-        footer.extend(["\n", f"验证：{notification.verification}"])
+        footer.extend([" · ", notification.verification])
     if notification.context:
-        footer.extend(["\n", f"上下文：{notification.context}"])
+        footer.extend([" · ", notification.context])
     blocks.append({"type": "footer", "text": footer})
     return blocks
 
@@ -158,21 +167,21 @@ def render_notification_blocks(notification: Notification) -> list[dict[str, Any
 def render_notification_plain(notification: Notification) -> str:
     """渲染终端预览使用的纯文本通知。"""
 
-    icon = STATUS_ICON[notification.status]
+    icon, status_label = STATUS_PRESENTATION[notification.status]
     lines = [
         notification.title,
         "",
-        notification.summary,
-        "",
-        "────────",
-        f"状态：{icon}",
+        f"> {notification.summary}",
     ]
     if notification.action:
-        lines.append(f"下一步：{notification.action}")
+        lines.extend(["", f"需要你处理：{notification.action}"])
+
+    footer = [f"{icon} {status_label}"]
     if notification.verification:
-        lines.append(f"验证：{notification.verification}")
+        footer.append(notification.verification)
     if notification.context:
-        lines.append(f"上下文：{notification.context}")
+        footer.append(notification.context)
+    lines.extend(["", " · ".join(footer)])
     return "\n".join(lines)
 
 

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -135,17 +135,21 @@ def render_notification_blocks(notification: Notification) -> list[dict[str, Any
     blocks: list[dict[str, Any]] = [
         {
             "type": "heading",
-            "text": f"{icon} {status_label}",
+            "text": f"{icon} Codex · {status_label}",
             "size": 3,
+        },
+        {
+            "type": "heading",
+            "text": notification.title,
+            "size": 4,
         },
         {
             "type": "paragraph",
             "text": [
-                {"type": "bold", "text": notification.title},
-                " · Codex",
+                {"type": "bold", "text": "结果："},
+                notification.summary,
             ],
         },
-        {"type": "paragraph", "text": notification.summary},
     ]
 
     if notification.action:
@@ -194,10 +198,10 @@ def render_notification_plain(notification: Notification) -> str:
 
     icon, status_label = STATUS_PRESENTATION[notification.status]
     lines = [
-        f"{icon} {status_label}",
-        f"{notification.title} · Codex",
+        f"{icon} Codex · {status_label}",
+        notification.title,
         "",
-        notification.summary,
+        f"结果：{notification.summary}",
     ]
     if notification.action:
         lines.extend(["", f"👉 下一步：{notification.action}"])

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -50,15 +50,12 @@ def test_render_notification_blocks_create_clear_visual_hierarchy() -> None:
     )
 
     assert notify.render_notification_blocks(notification) == [
-        {"type": "heading", "text": "✅ 修复 <Chat ID>", "size": 3},
+        {"type": "heading", "text": "✅ 任务完成", "size": 3},
         {
             "type": "paragraph",
-            "text": [{"type": "bold", "text": "任务完成"}, " · Codex"],
+            "text": [{"type": "bold", "text": "修复 <Chat ID>"}, " · Codex"],
         },
-        {
-            "type": "blockquote",
-            "blocks": [{"type": "paragraph", "text": "A & B"}],
-        },
+        {"type": "paragraph", "text": "A & B"},
         {
             "type": "paragraph",
             "text": ["👉 ", {"type": "bold", "text": "下一步："}, "重新执行"],
@@ -120,18 +117,15 @@ def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) 
         "chat_id": "test-chat",
         "rich_message": {
             "blocks": [
-                {"type": "heading", "text": "✅ 长任务完成", "size": 3},
+                {"type": "heading", "text": "✅ 任务完成", "size": 3},
                 {
                     "type": "paragraph",
                     "text": [
-                        {"type": "bold", "text": "任务完成"},
+                        {"type": "bold", "text": "长任务完成"},
                         " · Codex",
                     ],
                 },
-                {
-                    "type": "blockquote",
-                    "blocks": [{"type": "paragraph", "text": "所有步骤已经完成。"}],
-                },
+                {"type": "paragraph", "text": "所有步骤已经完成。"},
                 {"type": "divider"},
                 {
                     "type": "footer",
@@ -177,18 +171,15 @@ def test_json_preview_exposes_rich_message_without_config_or_network(
         "status": "action-required",
         "rich_message": {
             "blocks": [
-                {"type": "heading", "text": "⚠️ 需要确认", "size": 3},
+                {"type": "heading", "text": "⚠️ 等待你处理", "size": 3},
                 {
                     "type": "paragraph",
                     "text": [
-                        {"type": "bold", "text": "等待你处理"},
+                        {"type": "bold", "text": "需要确认"},
                         " · Codex",
                     ],
                 },
-                {
-                    "type": "blockquote",
-                    "blocks": [{"type": "paragraph", "text": "任务已暂停。"}],
-                },
+                {"type": "paragraph", "text": "任务已暂停。"},
                 {
                     "type": "paragraph",
                     "text": [
@@ -224,6 +215,6 @@ def test_preview_does_not_access_telegram(monkeypatch) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "❌ 长任务未完成" in result.output
-    assert "任务失败 · Codex" in result.output
+    assert "❌ 任务失败" in result.output
+    assert "长任务未完成 · Codex" in result.output
     assert "👉 下一步：检查构建日志" in result.output

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -52,31 +52,23 @@ def test_render_notification_blocks_create_clear_visual_hierarchy() -> None:
     assert notify.render_notification_blocks(notification) == [
         {
             "type": "paragraph",
-            "text": [
-                "✅ ",
-                {"type": "bold", "text": "标题"},
-                "：修复 <Chat ID>",
-            ],
+            "text": "修复 <Chat ID>",
         },
         {
             "type": "paragraph",
-            "text": [{"type": "bold", "text": "正文"}, "：A & B"],
-        },
-        {
-            "type": "paragraph",
-            "text": ["👉 ", {"type": "bold", "text": "下一步："}, "重新执行"],
+            "text": "A & B",
         },
         {"type": "divider"},
         {
             "type": "footer",
             "text": [
-                "🧪 ",
-                {"type": "bold", "text": "验证"},
-                "：157 > 0",
+                "状态：✅",
                 "\n",
-                "📦 ",
-                {"type": "bold", "text": "上下文"},
-                "：prompts",
+                "下一步：重新执行",
+                "\n",
+                "验证：157 > 0",
+                "\n",
+                "上下文：prompts",
             ],
         },
     ]
@@ -125,26 +117,19 @@ def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) 
             "blocks": [
                 {
                     "type": "paragraph",
-                    "text": [
-                        "✅ ",
-                        {"type": "bold", "text": "标题"},
-                        "：长任务完成",
-                    ],
+                    "text": "长任务完成",
                 },
                 {
                     "type": "paragraph",
-                    "text": [
-                        {"type": "bold", "text": "正文"},
-                        "：所有步骤已经完成。",
-                    ],
+                    "text": "所有步骤已经完成。",
                 },
                 {"type": "divider"},
                 {
                     "type": "footer",
                     "text": [
-                        "🧪 ",
-                        {"type": "bold", "text": "验证"},
-                        "：157 项测试通过",
+                        "状态：✅",
+                        "\n",
+                        "验证：157 项测试通过",
                     ],
                 },
             ]
@@ -185,25 +170,19 @@ def test_json_preview_exposes_rich_message_without_config_or_network(
             "blocks": [
                 {
                     "type": "paragraph",
-                    "text": [
-                        "⚠️ ",
-                        {"type": "bold", "text": "标题"},
-                        "：需要确认",
-                    ],
+                    "text": "需要确认",
                 },
                 {
                     "type": "paragraph",
-                    "text": [
-                        {"type": "bold", "text": "正文"},
-                        "：任务已暂停。",
-                    ],
+                    "text": "任务已暂停。",
                 },
+                {"type": "divider"},
                 {
-                    "type": "paragraph",
+                    "type": "footer",
                     "text": [
-                        "👉 ",
-                        {"type": "bold", "text": "下一步："},
-                        "选择发布范围",
+                        "状态：⚠️",
+                        "\n",
+                        "下一步：选择发布范围",
                     ],
                 },
             ]
@@ -233,6 +212,6 @@ def test_preview_does_not_access_telegram(monkeypatch) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "❌ 标题：长任务未完成" in result.output
-    assert "正文：构建失败。" in result.output
-    assert "👉 下一步：检查构建日志" in result.output
+    assert result.output == (
+        "长任务未完成\n\n构建失败。\n\n────────\n状态：❌\n下一步：检查构建日志\n"
+    )

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -50,10 +50,17 @@ def test_render_notification_blocks_create_clear_visual_hierarchy() -> None:
     )
 
     assert notify.render_notification_blocks(notification) == [
-        {"type": "heading", "text": "✅ 修复 <Chat ID>", "size": 3},
         {
             "type": "paragraph",
-            "text": [{"type": "bold", "text": "结果："}, "A & B"],
+            "text": [
+                "✅ ",
+                {"type": "bold", "text": "标题"},
+                "：修复 <Chat ID>",
+            ],
+        },
+        {
+            "type": "paragraph",
+            "text": [{"type": "bold", "text": "正文"}, "：A & B"],
         },
         {
             "type": "paragraph",
@@ -116,12 +123,19 @@ def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) 
         "chat_id": "test-chat",
         "rich_message": {
             "blocks": [
-                {"type": "heading", "text": "✅ 长任务完成", "size": 3},
                 {
                     "type": "paragraph",
                     "text": [
-                        {"type": "bold", "text": "结果："},
-                        "所有步骤已经完成。",
+                        "✅ ",
+                        {"type": "bold", "text": "标题"},
+                        "：长任务完成",
+                    ],
+                },
+                {
+                    "type": "paragraph",
+                    "text": [
+                        {"type": "bold", "text": "正文"},
+                        "：所有步骤已经完成。",
                     ],
                 },
                 {"type": "divider"},
@@ -169,12 +183,19 @@ def test_json_preview_exposes_rich_message_without_config_or_network(
         "status": "action-required",
         "rich_message": {
             "blocks": [
-                {"type": "heading", "text": "⚠️ 需要确认", "size": 3},
                 {
                     "type": "paragraph",
                     "text": [
-                        {"type": "bold", "text": "结果："},
-                        "任务已暂停。",
+                        "⚠️ ",
+                        {"type": "bold", "text": "标题"},
+                        "：需要确认",
+                    ],
+                },
+                {
+                    "type": "paragraph",
+                    "text": [
+                        {"type": "bold", "text": "正文"},
+                        "：任务已暂停。",
                     ],
                 },
                 {
@@ -212,6 +233,6 @@ def test_preview_does_not_access_telegram(monkeypatch) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "❌ 长任务未完成" in result.output
-    assert "结果：构建失败。" in result.output
+    assert "❌ 标题：长任务未完成" in result.output
+    assert "正文：构建失败。" in result.output
     assert "👉 下一步：检查构建日志" in result.output

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -51,25 +51,24 @@ def test_render_notification_blocks_create_clear_visual_hierarchy() -> None:
 
     assert notify.render_notification_blocks(notification) == [
         {
-            "type": "paragraph",
+            "type": "heading",
             "text": "修复 <Chat ID>",
+            "size": 4,
+        },
+        {
+            "type": "blockquote",
+            "blocks": [{"type": "paragraph", "text": "A & B"}],
         },
         {
             "type": "paragraph",
-            "text": "A & B",
+            "text": [
+                {"type": "marked", "text": "需要你处理"},
+                "：重新执行",
+            ],
         },
-        {"type": "divider"},
         {
             "type": "footer",
-            "text": [
-                "状态：✅",
-                "\n",
-                "下一步：重新执行",
-                "\n",
-                "验证：157 > 0",
-                "\n",
-                "上下文：prompts",
-            ],
+            "text": ["✅ 已完成", " · ", "157 > 0", " · ", "prompts"],
         },
     ]
 
@@ -116,21 +115,17 @@ def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) 
         "rich_message": {
             "blocks": [
                 {
-                    "type": "paragraph",
+                    "type": "heading",
                     "text": "长任务完成",
+                    "size": 4,
                 },
                 {
-                    "type": "paragraph",
-                    "text": "所有步骤已经完成。",
+                    "type": "blockquote",
+                    "blocks": [{"type": "paragraph", "text": "所有步骤已经完成。"}],
                 },
-                {"type": "divider"},
                 {
                     "type": "footer",
-                    "text": [
-                        "状态：✅",
-                        "\n",
-                        "验证：157 项测试通过",
-                    ],
+                    "text": ["✅ 已完成", " · ", "157 项测试通过"],
                 },
             ]
         },
@@ -169,22 +164,22 @@ def test_json_preview_exposes_rich_message_without_config_or_network(
         "rich_message": {
             "blocks": [
                 {
-                    "type": "paragraph",
+                    "type": "heading",
                     "text": "需要确认",
+                    "size": 4,
+                },
+                {
+                    "type": "blockquote",
+                    "blocks": [{"type": "paragraph", "text": "任务已暂停。"}],
                 },
                 {
                     "type": "paragraph",
-                    "text": "任务已暂停。",
-                },
-                {"type": "divider"},
-                {
-                    "type": "footer",
                     "text": [
-                        "状态：⚠️",
-                        "\n",
-                        "下一步：选择发布范围",
+                        {"type": "marked", "text": "需要你处理"},
+                        "：选择发布范围",
                     ],
                 },
+                {"type": "footer", "text": ["⚠️ 等待处理"]},
             ]
         },
     }
@@ -213,5 +208,5 @@ def test_preview_does_not_access_telegram(monkeypatch) -> None:
 
     assert result.exit_code == 0, result.output
     assert result.output == (
-        "长任务未完成\n\n构建失败。\n\n────────\n状态：❌\n下一步：检查构建日志\n"
+        "长任务未完成\n\n> 构建失败。\n\n需要你处理：检查构建日志\n\n❌ 未完成\n"
     )

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -50,12 +50,12 @@ def test_render_notification_blocks_create_clear_visual_hierarchy() -> None:
     )
 
     assert notify.render_notification_blocks(notification) == [
-        {"type": "heading", "text": "✅ 任务完成", "size": 3},
+        {"type": "heading", "text": "✅ Codex · 任务完成", "size": 3},
+        {"type": "heading", "text": "修复 <Chat ID>", "size": 4},
         {
             "type": "paragraph",
-            "text": [{"type": "bold", "text": "修复 <Chat ID>"}, " · Codex"],
+            "text": [{"type": "bold", "text": "结果："}, "A & B"],
         },
-        {"type": "paragraph", "text": "A & B"},
         {
             "type": "paragraph",
             "text": ["👉 ", {"type": "bold", "text": "下一步："}, "重新执行"],
@@ -117,15 +117,15 @@ def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) 
         "chat_id": "test-chat",
         "rich_message": {
             "blocks": [
-                {"type": "heading", "text": "✅ 任务完成", "size": 3},
+                {"type": "heading", "text": "✅ Codex · 任务完成", "size": 3},
+                {"type": "heading", "text": "长任务完成", "size": 4},
                 {
                     "type": "paragraph",
                     "text": [
-                        {"type": "bold", "text": "长任务完成"},
-                        " · Codex",
+                        {"type": "bold", "text": "结果："},
+                        "所有步骤已经完成。",
                     ],
                 },
-                {"type": "paragraph", "text": "所有步骤已经完成。"},
                 {"type": "divider"},
                 {
                     "type": "footer",
@@ -171,15 +171,15 @@ def test_json_preview_exposes_rich_message_without_config_or_network(
         "status": "action-required",
         "rich_message": {
             "blocks": [
-                {"type": "heading", "text": "⚠️ 等待你处理", "size": 3},
+                {"type": "heading", "text": "⚠️ Codex · 等待你处理", "size": 3},
+                {"type": "heading", "text": "需要确认", "size": 4},
                 {
                     "type": "paragraph",
                     "text": [
-                        {"type": "bold", "text": "需要确认"},
-                        " · Codex",
+                        {"type": "bold", "text": "结果："},
+                        "任务已暂停。",
                     ],
                 },
-                {"type": "paragraph", "text": "任务已暂停。"},
                 {
                     "type": "paragraph",
                     "text": [
@@ -215,6 +215,7 @@ def test_preview_does_not_access_telegram(monkeypatch) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "❌ 任务失败" in result.output
-    assert "长任务未完成 · Codex" in result.output
+    assert "❌ Codex · 任务失败" in result.output
+    assert "长任务未完成" in result.output
+    assert "结果：构建失败。" in result.output
     assert "👉 下一步：检查构建日志" in result.output

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -50,8 +50,7 @@ def test_render_notification_blocks_create_clear_visual_hierarchy() -> None:
     )
 
     assert notify.render_notification_blocks(notification) == [
-        {"type": "heading", "text": "✅ Codex · 任务完成", "size": 3},
-        {"type": "heading", "text": "修复 <Chat ID>", "size": 4},
+        {"type": "heading", "text": "✅ 修复 <Chat ID>", "size": 3},
         {
             "type": "paragraph",
             "text": [{"type": "bold", "text": "结果："}, "A & B"],
@@ -117,8 +116,7 @@ def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) 
         "chat_id": "test-chat",
         "rich_message": {
             "blocks": [
-                {"type": "heading", "text": "✅ Codex · 任务完成", "size": 3},
-                {"type": "heading", "text": "长任务完成", "size": 4},
+                {"type": "heading", "text": "✅ 长任务完成", "size": 3},
                 {
                     "type": "paragraph",
                     "text": [
@@ -171,8 +169,7 @@ def test_json_preview_exposes_rich_message_without_config_or_network(
         "status": "action-required",
         "rich_message": {
             "blocks": [
-                {"type": "heading", "text": "⚠️ Codex · 等待你处理", "size": 3},
-                {"type": "heading", "text": "需要确认", "size": 4},
+                {"type": "heading", "text": "⚠️ 需要确认", "size": 3},
                 {
                     "type": "paragraph",
                     "text": [
@@ -215,7 +212,6 @@ def test_preview_does_not_access_telegram(monkeypatch) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "❌ Codex · 任务失败" in result.output
-    assert "长任务未完成" in result.output
+    assert "❌ 长任务未完成" in result.output
     assert "结果：构建失败。" in result.output
     assert "👉 下一步：检查构建日志" in result.output

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import secrets
 import sys
 from pathlib import Path
 
-import pytest
 import tomllib
 from typer.testing import CliRunner
 
@@ -39,19 +39,9 @@ def test_config_set_accepts_negative_chat_id(tmp_path: Path) -> None:
         assert tomllib.load(config_file)["chat_id"] == chat_id
 
 
-@pytest.mark.parametrize(
-    ("status", "header"),
-    [
-        ("success", "✅ <b>Codex · 任务完成</b>"),
-        ("failed", "❌ <b>Codex · 任务失败</b>"),
-        ("action-required", "⚠️ <b>Codex · 等待你处理</b>"),
-    ],
-)
-def test_render_notification_html_uses_status_header_and_escapes_fields(
-    status: str, header: str
-) -> None:
+def test_render_notification_blocks_create_clear_visual_hierarchy() -> None:
     notification = notify.Notification(
-        status=status,
+        status="success",
         title="修复 <Chat ID>",
         summary="A & B",
         verification="157 > 0",
@@ -59,20 +49,37 @@ def test_render_notification_html_uses_status_header_and_escapes_fields(
         context="prompts",
     )
 
-    assert (
-        notify.render_notification_html(notification)
-        == f"""{header}
-<b>修复 &lt;Chat ID&gt;</b>
+    assert notify.render_notification_blocks(notification) == [
+        {"type": "heading", "text": "✅ 修复 <Chat ID>", "size": 3},
+        {
+            "type": "paragraph",
+            "text": [{"type": "bold", "text": "任务完成"}, " · Codex"],
+        },
+        {
+            "type": "blockquote",
+            "blocks": [{"type": "paragraph", "text": "A & B"}],
+        },
+        {
+            "type": "paragraph",
+            "text": ["👉 ", {"type": "bold", "text": "下一步："}, "重新执行"],
+        },
+        {"type": "divider"},
+        {
+            "type": "footer",
+            "text": [
+                "🧪 ",
+                {"type": "bold", "text": "验证"},
+                "：157 > 0",
+                "\n",
+                "📦 ",
+                {"type": "bold", "text": "上下文"},
+                "：prompts",
+            ],
+        },
+    ]
 
-A &amp; B
 
-🧪 验证：157 &gt; 0
-👉 下一步：重新执行
-📦 上下文：prompts"""
-    )
-
-
-def test_send_uses_structured_html_payload(monkeypatch, tmp_path: Path) -> None:
+def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(
@@ -108,16 +115,90 @@ def test_send_uses_structured_html_payload(monkeypatch, tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert captured["method"] == "sendMessage"
+    assert captured["method"] == "sendRichMessage"
     assert captured["payload"] == {
         "chat_id": "test-chat",
-        "text": """✅ <b>Codex · 任务完成</b>
-<b>长任务完成</b>
+        "rich_message": {
+            "blocks": [
+                {"type": "heading", "text": "✅ 长任务完成", "size": 3},
+                {
+                    "type": "paragraph",
+                    "text": [
+                        {"type": "bold", "text": "任务完成"},
+                        " · Codex",
+                    ],
+                },
+                {
+                    "type": "blockquote",
+                    "blocks": [{"type": "paragraph", "text": "所有步骤已经完成。"}],
+                },
+                {"type": "divider"},
+                {
+                    "type": "footer",
+                    "text": [
+                        "🧪 ",
+                        {"type": "bold", "text": "验证"},
+                        "：157 项测试通过",
+                    ],
+                },
+            ]
+        },
+    }
 
-所有步骤已经完成。
 
-🧪 验证：157 项测试通过""",
-        "parse_mode": "HTML",
+def test_json_preview_exposes_rich_message_without_config_or_network(
+    monkeypatch,
+) -> None:
+    def unexpected_access(*_args, **_kwargs):
+        raise AssertionError("preview must not access config or Telegram")
+
+    monkeypatch.setattr(notify, "complete_config", unexpected_access)
+    monkeypatch.setattr(notify, "telegram_call", unexpected_access)
+
+    result = CliRunner().invoke(
+        notify.app,
+        [
+            "--json",
+            "preview",
+            "--status",
+            "action-required",
+            "--title",
+            "需要确认",
+            "--summary",
+            "任务已暂停。",
+            "--action",
+            "选择发布范围",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.endswith("\n")
+    assert json.loads(result.output) == {
+        "status": "action-required",
+        "rich_message": {
+            "blocks": [
+                {"type": "heading", "text": "⚠️ 需要确认", "size": 3},
+                {
+                    "type": "paragraph",
+                    "text": [
+                        {"type": "bold", "text": "等待你处理"},
+                        " · Codex",
+                    ],
+                },
+                {
+                    "type": "blockquote",
+                    "blocks": [{"type": "paragraph", "text": "任务已暂停。"}],
+                },
+                {
+                    "type": "paragraph",
+                    "text": [
+                        "👉 ",
+                        {"type": "bold", "text": "下一步："},
+                        "选择发布范围",
+                    ],
+                },
+            ]
+        },
     }
 
 
@@ -143,5 +224,6 @@ def test_preview_does_not_access_telegram(monkeypatch) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "❌ Codex · 任务失败" in result.output
+    assert "❌ 长任务未完成" in result.output
+    assert "任务失败 · Codex" in result.output
     assert "👉 下一步：检查构建日志" in result.output


### PR DESCRIPTION
## Why

- 长任务通知需要让用户离开终端后快速识别具体任务、最终结论和必要证据，而不必持续查看终端。
- Telegram 已提供面向结构化报告和 AI 输出的 Rich Message，需要为当前通知选择稳定、克制的块级表达，并沉淀可复用的 API 选型边界。

## What

- 将 `notify-via-telegram` 的发送协议切换为 `sendRichMessage`：任务名称作为唯一 heading，最终结论使用 blockquote；仅在需要用户处理时显示高亮行动项，状态、验证和上下文压缩为单行 footer。`preview --json` 返回与发送请求同构的 `rich_message`。
- 禁止 skill 隐式触发，仅在用户显式调用 `$notify-via-telegram` 后订阅当前长任务结果。
- 在 `dcjanus-preferences` 中新增 Telegram Bot API 消息能力 reference，约定简单消息使用 `sendMessage`，需要强结构表现力时使用 `sendRichMessage`，并说明 blocks、draft、兼容性与容量边界。

## BREAKING CHANGE

影响范围：

- 自然语言中的通知要求不再自动加载该 skill。
- `preview --json` 不再返回 HTML `text` / `parse_mode`，发送端也不再调用 `sendMessage`。

迁移方式：

- 使用 `$notify-via-telegram` 显式订阅当前任务的 Telegram 结果通知。
- JSON 调用方改读 `rich_message.blocks`；目标 Bot API 需支持 `sendRichMessage` 与 `InputRichMessage.blocks`。
