### PR TITLE
docs(dcjanus-preferences): 记录 Protobuf presence 偏好

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ notification_method = "bel"
 | [`confluence-cli`](skills/confluence-cli/SKILL.md) | 查询、检索与阅读 Confluence 文档/页面。 |
 | [`jira-cli`](skills/jira-cli/SKILL.md) | 通过内置 Python CLI 查询和管理 Jira Issue、Saved Filter、流转与评论。 |
 | [`uv-cli-creator`](skills/uv-cli-creator/SKILL.md) | 创建或修改基于 PEP 723、由 `uv run --script` 管理的单文件 Python CLI，并在环境支持时提供直接执行入口。 |
-| [`dcjanus-preferences`](skills/dcjanus-preferences/SKILL.md) | 记录 DCjanus 的跨语言技术选型以及 Python/Rust/Go 第三方库偏好，适用于存储、分析、压缩、归档、依赖选择与技术方案对比。 |
+| [`dcjanus-preferences`](skills/dcjanus-preferences/SKILL.md) | 记录 DCjanus 的跨语言技术选型、Protobuf 契约以及 Python/Rust/Go 第三方库偏好，适用于存储、分析、压缩、归档、协议设计、依赖选择与技术方案对比。 |
 | [`domain-modeling`](skills/domain-modeling/SKILL.md) | 构建并持续校准领域模型，明确领域术语与边界，并在必要时记录重要架构决策。 |
 | [`fetch-url`](skills/fetch-url/SKILL.md) | 获取并提取链接正文（默认 Markdown）；内置 X/Twitter URL 处理，提升受限页面的抓取成功率。 |
 | [`review-fix-loop`](skills/review-fix-loop/SKILL.md) | 用三个相互隔离的干净 subagent 并行做代码审查，由主 agent 判断审查意见价值、修复有效问题并提交推送，直到同一批三个 reviewer 都没有有价值审查意见；仅在显式调用时启用。 |

--- a/skills/dcjanus-preferences/SKILL.md
+++ b/skills/dcjanus-preferences/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dcjanus-preferences
-description: 记录 DCjanus 的跨语言技术选型、API 能力选择以及 Python/Rust/Go 第三方库偏好，供 AI 在存储、分析、压缩、归档、消息呈现、引入依赖或替换库时优先参考。适用于技术方案对比或需要遵循 DCjanus 个人偏好进行开发的场景。
+description: 记录 DCjanus 的跨语言技术选型、API 与 Protobuf 契约选择以及 Python/Rust/Go 第三方库偏好，供 AI 在存储、分析、压缩、归档、消息呈现、协议设计、引入依赖或替换库时优先参考。适用于技术方案对比或需要遵循 DCjanus 个人偏好进行开发的场景。
 ---
 
 ## Usage
 
-- 先确认选型问题是否跨语言：数据库、分析、压缩或归档场景读取 `references/data-storage.md`；Telegram Bot 消息能力选择读取 `references/telegram-bot-api.md`；语言生态库选择则读取对应语言参考文件。
+- 先确认选型问题是否跨语言：数据库、分析、压缩或归档场景读取 `references/data-storage.md`；Protobuf 字段 presence 与兼容性判断读取 `references/protobuf.md`；Telegram Bot 消息能力选择读取 `references/telegram-bot-api.md`；语言生态库选择则读取对应语言参考文件。
 - 引入或替换第三方库时优先使用偏好清单。
 - 当工作负载同时具有多种特征、偏好清单未覆盖或与明确需求冲突时，先说明主要工作负载、取舍与建议；结论仍不明确时再向用户确认。
 - 新增语言时创建 `references/<language>.md`；新增跨语言主题时创建聚焦该主题的 reference，避免将无关偏好堆入泛化的 general 文件。
@@ -19,6 +19,7 @@ description: 记录 DCjanus 的跨语言技术选型、API 能力选择以及 Py
 ## References
 
 - 跨语言数据存储、分析、压缩与归档：`references/data-storage.md`
+- Protobuf 字段 presence 与兼容性：`references/protobuf.md`
 - Telegram Bot API 消息能力选择：`references/telegram-bot-api.md`
 - Python: `references/python.md`
 - Rust: `references/rust.md`

--- a/skills/dcjanus-preferences/references/protobuf.md
+++ b/skills/dcjanus-preferences/references/protobuf.md
@@ -1,0 +1,12 @@
+# Protobuf
+
+- Proto3 的 scalar、enum、string 和 bytes 字段，如果业务上不需要区分“未提供”和对应零值，默认省略显式 `optional`，让零值同时表示未指定。枚举应提供语义清楚的零值（例如 `*_UNSPECIFIED`）；查询条件可用空字符串或零值表示不参与筛选。
+- 只有当 API 语义确实依赖 presence 时才使用 `optional`，例如必须区分“未提供”和 `0`、`false`、空字符串或零值枚举，或部分更新需要在没有 `FieldMask` 的情况下显式写入零值。
+- Proto3 的 singular message 字段本身就有 explicit presence，通常不再添加冗余的 `optional`；`oneof` 也自带 presence。repeated 和 map 不区分未提供与空集合。
+- 该偏好有意优先保持契约和生成代码简洁，不把 Protobuf 官方“basic types 总是添加 optional”的迁移建议作为默认；若外部协议、既有客户端、代码生成器、Edition 迁移或明确的 presence 语义提出不同要求，以实际兼容性约束为准。
+
+## 兼容性判断
+
+- Proto3 scalar、enum、string 或 bytes 字段在隐式 presence 与显式 `optional` 之间转换时，字段号和 wire type 不变，因此二进制 wire 格式兼容；但生成代码的字段表示与 presence API 可能变化，显式设置零值时的序列化和 merge 行为也不同，混用新旧客户端还可能丢失 presence。
+- 因此，非 `optional` 改为 `optional` 不应笼统称为 wire breaking change，但对已经发布并有生成代码消费者的 API，应按潜在 source/API breaking change 和应用语义变化审查。使用严格 `FILE` 或 `PACKAGE` 类别时，Buf 可能通过 `FIELD_SAME_CARDINALITY` 报告该变化；仍需重新生成代码并检查直接消费者。
+- 对 singular message 字段，添加或移除 `optional` 不改变其既有 explicit presence；Buf 也不认为这会改变 cardinality。即使如此，仍应以仓库实际生成器和兼容性检查结果为准。


### PR DESCRIPTION
## Why

- Proto3 字段是否使用显式 `optional` 需要按 presence 语义判断，避免在不需要区分未提供与零值时增加生成代码复杂度。
- 字段 presence 调整虽然保持二进制 wire 兼容，但仍可能影响生成代码和应用语义，需要形成可复用的兼容性判断边界。

## What

- 为 `dcjanus-preferences` 新增 Protobuf 参考，记录 implicit/explicit presence、`optional` 使用条件以及字段演进的兼容性判断。
- 更新 skill 路由、描述和仓库技能索引，使 Protobuf 契约设计场景能够发现并读取该偏好。
