### PR TITLE
fix(repository-workflow): 强化 PR/MR 验证证据门禁

### DIFF
--- a/skills/repository-workflow/SKILL.md
+++ b/skills/repository-workflow/SKILL.md
@@ -89,8 +89,10 @@ git status -sb
 1. 完整读取 [change-requests.md](references/change-requests.md)；PR/MR 标题同时读取 [commit-messages.md](references/commit-messages.md)。
 2. 根据平台同时使用 `github-cli` 或 `gitlab-cli` 完成模板检查、资源读取和实际写入。
 3. 创建或更新前核对平台当前内容与最终本地状态；独立 Issue 按 reference 中的例外处理。
-4. 多行正文先写入临时 Markdown 文件，再通过平台命令的 file 参数提交，不在 shell 中拼接。
-5. 写入后回读标题、正文、状态和必要的元数据，确认平台结果与预期一致。
+4. 起草 PR/MR 正文时默认不添加 `Validation`。它不是测试清单：只有 reviewer 无法从最终 diff 和平台 CI/checks 直接获得、且会实质影响风险判断的最终行为证据才能保留。普通检查命令、测试数量和 CI 状态只在任务交付回复中汇报。具体筛选规则和正反例见 [change-requests.md](references/change-requests.md)。
+5. 多行正文先写入临时 Markdown 文件，再通过平台命令的 file 参数提交，不在 shell 中拼接。
+6. 写入平台前重新通读完整正文并按最终净变化复核；删除实现过程、普通验证流水账和其它不符合 reference 的内容。若 `Validation` 没有合格证据，删除整个章节。
+7. 写入后回读标题、正文、状态和必要的元数据，确认平台结果与预期一致。
 
 ## 最终可合并门禁
 

--- a/skills/repository-workflow/references/change-requests.md
+++ b/skills/repository-workflow/references/change-requests.md
@@ -40,14 +40,48 @@ git diff --name-status <base-or-target>...HEAD
 
 ## Validation Gate
 
-默认不写 `## Validation`；不确定时也省略。只有同时满足以下条件时才添加：
+`Validation` 不是测试清单。起草 PR/MR 时默认从没有 `## Validation` 的正文开始；不确定是否需要时也省略。只有同时满足以下条件的证据才能加入：
 
 1. 证据不在 final diff、平台 CI/checks、pipeline 或标准合入门槛中自然可见。
 2. 证据会改变 reviewer 对风险的判断，而不是证明执行过测试。
 3. 证据描述最终交付行为，而不是探索过程或临时调试。
 4. 证据可以用行为结果表达，而不是命令流水账。
 
-普通 lint、fmt、typecheck、build、测试、coverage、CI 状态、命令清单和测试数量都不要写入 Validation。允许的证据包括 CI 无法覆盖的真实环境行为、迁移 dry-run、性能数据、兼容性矩阵、安全边界或刻意构造的 red/green 回归结果。只写验证的行为和结果。
+发送前逐项筛除 `Validation` 中的内容：
+
+1. final diff、CI/checks 或 pipeline 已经能直接展示的证据，删除。
+2. 只用于证明“执行过检查”的 lint、fmt、typecheck、build、普通测试、coverage、CI 状态、命令和测试数量，删除。
+3. 记录启动服务、打开工具、调试步骤或失败尝试等过程的内容，删除；如果其中存在有价值的最终行为证据，只保留可观察结果。
+4. 不会改变 reviewer 风险判断的结果，删除。
+
+筛选后没有合格证据时，删除整个章节。允许保留的内容包括 CI 无法覆盖的真实环境行为、迁移 dry-run 结果、性能数据、兼容性矩阵、安全边界或刻意构造的 red/green 回归结果。用户笼统要求“包含验证”时仍应用本门禁；普通检查在任务交付回复中完整汇报，除非用户明确要求将具体命令写入 reviewer-facing 正文。
+
+错误示例：把常规检查结果写成命令清单；这些信息应由 CI 或任务交付回复承载。
+
+```markdown
+## Validation
+
+- `npm run type-check`
+- `npm run lint`
+- `npm run test:unit`：1486 条用例通过
+- Pipeline passed
+```
+
+错误示例：只描述操作过程和笼统结论，reviewer 无法判断实际验证了什么行为。
+
+```markdown
+## Validation
+
+- 本地启动 dev server，并使用 Chrome 简单验收，未发现问题。
+```
+
+正确示例：CI 无法覆盖的 test 环境行为会直接降低本次筛选规则变更的风险。
+
+```markdown
+## Validation
+
+- test 环境的逻辑集群列表中，`cluster:infra_platform` 可以命中名称包含 `infra-platform` 的集群，URL 仍保留用户输入的原始筛选值。
+```
 
 ## Inline review reply
 


### PR DESCRIPTION
## Why

现有 Validation Gate 虽然说明了证据范围，但 PR/MR 主流程缺少发送前的明确复核步骤，Agent 仍可能把普通检查命令或操作过程写入 reviewer-facing 正文。

## What

- 将 Validation 门禁提升到 repository-workflow 主流程，默认省略该章节，并在平台写入前删除普通验证流水账和不合格证据。
- 把 reference 中的抽象条件改写为逐项筛除规则，明确“包含验证”的一般要求不会绕过门禁。
- 增加命令清单、模糊本地验收的负面例子，以及描述真实环境可观察行为的正面例子。
