### PR TITLE
feat: 新增 Google Sheets 建表并统一 Ruff 检查

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,20 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: false
+      - name: Check Python formatting
+        run: uvx ruff format --check .
+      - name: Check Python lint
+        run: uvx ruff check .
+
   script-dependency-check:
     runs-on: ubuntu-latest
     steps:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+[lint]
+external = ["E402", "N802", "S310"]
+
+[lint.flake8-bugbear]
+extend-immutable-calls = ["typer.Argument", "typer.Option"]

--- a/skills/confluence-cli/scripts/confluence_api_client.py
+++ b/skills/confluence-cli/scripts/confluence_api_client.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import base64
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import Any
 
 import httpxyz
@@ -59,7 +59,7 @@ class ConfluenceApiClient:
     def _build_headers(config: ConfluenceConfig) -> dict[str, str]:
         headers = {"Accept": "application/json"}
         if config.username:
-            raw = f"{config.username}:{config.token}".encode("utf-8")
+            raw = f"{config.username}:{config.token}".encode()
             headers["Authorization"] = f"Basic {base64.b64encode(raw).decode('utf-8')}"
         else:
             headers["Authorization"] = f"Bearer {config.token}"

--- a/skills/confluence-cli/scripts/confluence_cli.py
+++ b/skills/confluence-cli/scripts/confluence_cli.py
@@ -20,13 +20,14 @@ import struct
 import sys
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
+import typer
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
-import typer
 from pydantic import BaseModel
 from rich.console import Console
 from rich.table import Table
@@ -551,7 +552,7 @@ def validate_token_attributes(token: Token) -> dict[str, str]:
 def normalize_table_cell_style(style: str) -> str:
     """只允许 Markdown table alignment 生成的安全 text-align style。"""
     match = re.fullmatch(
-        r"\s*text-align\s*:\s*(left|center|right)\s*;?\s*", style, re.I
+        r"\s*text-align\s*:\s*(left|center|right)\s*;?\s*", style, re.IGNORECASE
     )
     if not match:
         raise ApiError(f"Unsupported Markdown table cell style: {style}")
@@ -894,7 +895,7 @@ def upload_attachments(
 def build_auth_headers(state: AppState) -> dict[str, str]:
     """构造 Confluence API 认证头。"""
     if state.username:
-        raw = f"{state.username}:{state.token}".encode("utf-8")
+        raw = f"{state.username}:{state.token}".encode()
         encoded = base64.b64encode(raw).decode("utf-8")
         return {"Authorization": f"Basic {encoded}"}
     return {"Authorization": f"Bearer {state.token}"}
@@ -1209,13 +1210,15 @@ def download_attachments(
         target_url = f"{state.base_url.rstrip('/')}{download_link}"
         target_path = output_dir / title
         request = urllib.request.Request(target_url, headers=headers)
-        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
-            with target_path.open("wb") as f:
-                while True:
-                    chunk = response.read(1024 * 1024)
-                    if not chunk:
-                        break
-                    f.write(chunk)
+        with (
+            urllib.request.urlopen(request, timeout=timeout_seconds) as response,
+            target_path.open("wb") as f,
+        ):
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                f.write(chunk)
         downloaded.append(title)
     summary = {
         "output_dir": str(output_dir),
@@ -1373,7 +1376,7 @@ def main_entry() -> None:
     except ApiError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"[red]Unhandled error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
 

--- a/skills/confluence-cli/scripts/tests/test_markdown_to_storage.py
+++ b/skills/confluence-cli/scripts/tests/test_markdown_to_storage.py
@@ -3,8 +3,8 @@ import struct
 import sys
 import tempfile
 import types
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 
 def install_test_stubs():

--- a/skills/fetch-url/scripts/fetch_url.py
+++ b/skills/fetch-url/scripts/fetch_url.py
@@ -14,21 +14,21 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 import re
-from typing import Any, Literal
+from pathlib import Path
 from time import monotonic
+from typing import Any, Literal
 from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
+import trafilatura
 import typer
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
 from rich.console import Console
 from rich.panel import Panel
-import trafilatura
 
 APP = typer.Typer(add_completion=False)
 CONSOLE = Console()
@@ -573,42 +573,41 @@ def fetch(
                         "[green]Using FxTwitter API markdown path[/green]",
                         highlight=False,
                     )
-        if output_format == "markdown":
-            if content is None:
-                if fetch_strategy == "auto":
-                    content = fetch_agent_markdown(
-                        url, timeout_ms=timeout_ms, verbose=verbose
-                    )
-                    if content is None:
-                        content = fetch_jina_reader_markdown(
-                            url,
-                            timeout_ms=timeout_ms,
-                            verbose=verbose,
-                        )
-                elif fetch_strategy == "agent":
-                    content = fetch_agent_markdown(
-                        url, timeout_ms=timeout_ms, verbose=verbose
-                    )
-                    if content is None:
-                        raise ValueError(
-                            "Markdown negotiation did not return usable content. "
-                            "Try --fetch-strategy jina or --fetch-strategy browser."
-                        )
-                elif fetch_strategy == "jina":
+        if output_format == "markdown" and content is None:
+            if fetch_strategy == "auto":
+                content = fetch_agent_markdown(
+                    url, timeout_ms=timeout_ms, verbose=verbose
+                )
+                if content is None:
                     content = fetch_jina_reader_markdown(
-                        url, timeout_ms=timeout_ms, verbose=verbose
+                        url,
+                        timeout_ms=timeout_ms,
+                        verbose=verbose,
                     )
-                    if content is None:
-                        raise ValueError(
-                            "Jina Reader did not return usable content. "
-                            f"If this is rate limiting, configure {JINA_API_KEY_ENV} or try "
-                            "--fetch-strategy browser."
-                        )
-                elif fetch_strategy == "browser" and verbose:
-                    CONSOLE.print(
-                        "[cyan]Skipping non-browser markdown readers[/cyan]",
-                        highlight=False,
+            elif fetch_strategy == "agent":
+                content = fetch_agent_markdown(
+                    url, timeout_ms=timeout_ms, verbose=verbose
+                )
+                if content is None:
+                    raise ValueError(
+                        "Markdown negotiation did not return usable content. "
+                        "Try --fetch-strategy jina or --fetch-strategy browser."
                     )
+            elif fetch_strategy == "jina":
+                content = fetch_jina_reader_markdown(
+                    url, timeout_ms=timeout_ms, verbose=verbose
+                )
+                if content is None:
+                    raise ValueError(
+                        "Jina Reader did not return usable content. "
+                        f"If this is rate limiting, configure {JINA_API_KEY_ENV} or try "
+                        "--fetch-strategy browser."
+                    )
+            elif fetch_strategy == "browser" and verbose:
+                CONSOLE.print(
+                    "[cyan]Skipping non-browser markdown readers[/cyan]",
+                    highlight=False,
+                )
         if content is None:
             html = render_html(
                 url,

--- a/skills/github-cli/scripts/configure_squash_merge_policy.py
+++ b/skills/github-cli/scripts/configure_squash_merge_policy.py
@@ -96,7 +96,7 @@ def run_gh_api(
     except json.JSONDecodeError as exc:
         raise RuntimeError("gh api did not return valid JSON") from exc
     if not isinstance(parsed, dict):
-        raise RuntimeError("unexpected API response shape")
+        raise TypeError("unexpected API response shape")
     return parsed
 
 
@@ -161,7 +161,7 @@ def main(
         ..., "--repo", help="GitHub repository，格式 owner/repo。"
     ),
     cwd: Path = typer.Option(
-        Path.cwd(),
+        Path(),
         "--cwd",
         resolve_path=True,
         file_okay=False,

--- a/skills/github-cli/scripts/github_preflight.py
+++ b/skills/github-cli/scripts/github_preflight.py
@@ -19,7 +19,6 @@ import typer
 import yaml
 from rich.console import Console
 
-
 app = typer.Typer(
     add_completion=False, help="输出中文 GitHub issue/PR 创建前静态检查摘要"
 )

--- a/skills/github-cli/scripts/tests/test_configure_squash_merge_policy.py
+++ b/skills/github-cli/scripts/tests/test_configure_squash_merge_policy.py
@@ -4,7 +4,6 @@ import importlib.util
 import json
 from pathlib import Path
 
-
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "configure_squash_merge_policy.py"
 SPEC = importlib.util.spec_from_file_location(
     "configure_squash_merge_policy", SCRIPT_PATH

--- a/skills/github-cli/scripts/tests/test_github_issue.py
+++ b/skills/github-cli/scripts/tests/test_github_issue.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "github_issue.py"
 SPEC = importlib.util.spec_from_file_location("github_issue", SCRIPT_PATH)
 assert SPEC is not None

--- a/skills/gitlab-cli/scripts/configure_squash_merge_policy.py
+++ b/skills/gitlab-cli/scripts/configure_squash_merge_policy.py
@@ -105,7 +105,7 @@ def run_glab_api(
     except json.JSONDecodeError as exc:
         raise RuntimeError("glab api did not return valid JSON") from exc
     if not isinstance(parsed, dict):
-        raise RuntimeError("unexpected API response shape")
+        raise TypeError("unexpected API response shape")
     return parsed
 
 
@@ -169,7 +169,7 @@ def main(
         ..., "--project", help="GitLab project id 或 group/project。"
     ),
     cwd: Path = typer.Option(
-        Path.cwd(),
+        Path(),
         "--cwd",
         resolve_path=True,
         file_okay=False,

--- a/skills/gitlab-cli/scripts/gitlab_cli.py
+++ b/skills/gitlab-cli/scripts/gitlab_cli.py
@@ -241,7 +241,7 @@ def run_glab_api(
         ) from exc
 
     if not isinstance(parsed, dict):
-        raise RuntimeError("unexpected API response shape")
+        raise TypeError("unexpected API response shape")
     return parsed
 
 
@@ -343,7 +343,7 @@ def print_resource_result(resource_name: str, payload: dict[str, object]) -> Non
 def ci_lint(
     path: Path = typer.Argument(Path(".gitlab-ci.yml"), help="要校验的 CI 配置文件。"),
     cwd: Path = typer.Option(
-        Path.cwd(),
+        Path(),
         "--cwd",
         resolve_path=True,
         file_okay=False,
@@ -428,7 +428,7 @@ def mr_create(
     title: str = typer.Option(..., "--title", help="MR 标题。"),
     target_branch: str = typer.Option(..., "--target-branch", help="目标分支。"),
     cwd: Path = typer.Option(
-        Path.cwd(),
+        Path(),
         "--cwd",
         resolve_path=True,
         file_okay=False,
@@ -506,7 +506,7 @@ def mr_create(
 def mr_update(
     iid: int = typer.Argument(..., help="要更新的 MR IID。"),
     cwd: Path = typer.Option(
-        Path.cwd(),
+        Path(),
         "--cwd",
         resolve_path=True,
         file_okay=False,
@@ -580,7 +580,7 @@ def mr_update(
 def issue_create(
     title: str = typer.Option(..., "--title", help="Issue 标题。"),
     cwd: Path = typer.Option(
-        Path.cwd(),
+        Path(),
         "--cwd",
         resolve_path=True,
         file_okay=False,
@@ -644,7 +644,7 @@ def issue_create(
 def issue_update(
     iid: int = typer.Argument(..., help="要更新的 Issue IID。"),
     cwd: Path = typer.Option(
-        Path.cwd(),
+        Path(),
         "--cwd",
         resolve_path=True,
         file_okay=False,

--- a/skills/gitlab-cli/scripts/tests/test_configure_squash_merge_policy.py
+++ b/skills/gitlab-cli/scripts/tests/test_configure_squash_merge_policy.py
@@ -4,7 +4,6 @@ import importlib.util
 import json
 from pathlib import Path
 
-
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "configure_squash_merge_policy.py"
 SPEC = importlib.util.spec_from_file_location(
     "configure_squash_merge_policy", SCRIPT_PATH

--- a/skills/gitlab-cli/scripts/tests/test_gitlab_cli.py
+++ b/skills/gitlab-cli/scripts/tests/test_gitlab_cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "gitlab_cli.py"
 SPEC = importlib.util.spec_from_file_location("gitlab_cli", SCRIPT_PATH)
 assert SPEC is not None

--- a/skills/google-mail-cli/scripts/google_mail_cli.py
+++ b/skills/google-mail-cli/scripts/google_mail_cli.py
@@ -14,8 +14,6 @@
 """面向 Codex skill 的 Gmail API 命令行工具。"""
 
 # Typer 以 Option(...) 作为声明式参数元数据，B008 在这里不适用。
-# ruff: noqa: B008
-
 from __future__ import annotations
 
 import base64

--- a/skills/google-sheets-cli/SKILL.md
+++ b/skills/google-sheets-cli/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: google-sheets-cli
-description: 使用 Python CLI 与 Google Sheets API 交互以读取、更新、批量写入、追加或清空 Google Sheets 在线表格；适用于需要通过 OAuth 授权操作 Google Workspace 表格的场景。
+description: 使用 Python CLI 与 Google Sheets API 交互以新建、读取、更新、批量写入、追加或清空 Google Sheets 在线表格；适用于需要通过 OAuth 授权操作 Google Workspace 表格的场景。
 ---
 
 # google-sheets-cli
 
-通过本 skill 调用 Google Sheets API。适合读取和编辑 Google Sheets 在线文档中的单元格值。
+通过本 skill 调用 Google Sheets API。适合新建、读取和编辑 Google Sheets 在线文档。
 
 ## 执行约定
 
@@ -33,17 +33,22 @@ OAuth 通常只需要配置一次；日常任务不要把认证细节加载进�
 常用命令族：
 
 - `auth login|doctor|logout|paths`
-- `spreadsheet get`
+- `spreadsheet create|get`
 - `values get|update|batch-update|append|clear|update-rich-text`
 
 示例：
 
 ```bash
+./scripts/gsheets_cli.py --json spreadsheet create \
+  --title "审计结果" --sheet-title "问题" --sheet-title "说明" \
+  --frozen-row-count 1
 ./scripts/gsheets_cli.py --json spreadsheet get --spreadsheet-id <spreadsheet-id>
 ./scripts/gsheets_cli.py --json values get --spreadsheet-id <spreadsheet-id> --range "Sheet1!A1:D20"
 ./scripts/gsheets_cli.py --json values update --spreadsheet-id <spreadsheet-id> --range "Sheet1!B2" --values-json '[["DONE"]]'
 ./scripts/gsheets_cli.py --json values append --spreadsheet-id <spreadsheet-id> --range "Sheet1!A:D" --values-json '[["a","b","c","d"]]'
 ```
+
+`values update|batch-update|append` 的每个单元格必须是 JSON 标量：string、number、boolean 或 null。Mongo Extended JSON 等对象值需先转换为字符串或拆成独立列；CLI 会在请求前报告具体的行列位置，避免收到难以定位的 Google API 400。
 
 批量写入：
 

--- a/skills/google-sheets-cli/scripts/gsheets_cli.py
+++ b/skills/google-sheets-cli/scripts/gsheets_cli.py
@@ -14,11 +14,12 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import typer
 from google.auth.exceptions import GoogleAuthError, RefreshError
@@ -127,7 +128,40 @@ def load_json_arg(raw: str, option_name: str) -> Any:
 def ensure_2d_values(value: Any, option_name: str) -> list[list[Any]]:
     if not isinstance(value, list) or any(not isinstance(row, list) for row in value):
         raise CliError(f'{option_name} 必须是二维 JSON 数组，例如 [["A", "B"]]。')
+    for row_index, row in enumerate(value):
+        for column_index, cell in enumerate(row):
+            if not isinstance(cell, (str, int, float, bool, type(None))):
+                raise CliError(
+                    f"{option_name}[{row_index}][{column_index}] 必须是 "
+                    "string、number、boolean 或 null，不能直接写入 JSON 对象或数组。"
+                )
+            if isinstance(cell, float) and not math.isfinite(cell):
+                raise CliError(
+                    f"{option_name}[{row_index}][{column_index}] 必须是有限数值。"
+                )
     return value
+
+
+def spreadsheet_create_body(
+    title: str, sheet_titles: list[str], frozen_row_count: int
+) -> dict[str, Any]:
+    """构造新建 Spreadsheet 请求并校验工作表名称。"""
+
+    normalized_title = title.strip()
+    if not normalized_title:
+        raise CliError("--title 不能为空。")
+    normalized_sheets = [item.strip() for item in sheet_titles]
+    if not normalized_sheets or any(not item for item in normalized_sheets):
+        raise CliError("--sheet-title 至少需要一个非空名称。")
+    if len(set(normalized_sheets)) != len(normalized_sheets):
+        raise CliError("--sheet-title 不能重复。")
+    sheets = []
+    for sheet_title in normalized_sheets:
+        properties: dict[str, Any] = {"title": sheet_title}
+        if frozen_row_count:
+            properties["gridProperties"] = {"frozenRowCount": frozen_row_count}
+        sheets.append({"properties": properties})
+    return {"properties": {"title": normalized_title}, "sheets": sheets}
 
 
 def ensure_batch_updates(value: Any, option_name: str) -> list[dict[str, Any]]:
@@ -458,6 +492,36 @@ def spreadsheet_get(
     except HttpError as exc:
         raise handle_http_error(exc) from exc
     render_output(ctx, payload, "Spreadsheet")
+
+
+@spreadsheet_app.command("create", help="新建 spreadsheet 和初始工作表。")
+def spreadsheet_create(
+    ctx: typer.Context,
+    title: Annotated[str, typer.Option("--title", help="Spreadsheet 标题。")],
+    sheet_titles: Annotated[
+        list[str] | None,
+        typer.Option("--sheet-title", help="可重复；指定初始工作表名称。"),
+    ] = None,
+    frozen_row_count: Annotated[
+        int,
+        typer.Option(
+            "--frozen-row-count",
+            min=0,
+            help="每个初始工作表冻结的顶部行数。",
+        ),
+    ] = 0,
+) -> None:
+    body = spreadsheet_create_body(title, sheet_titles or ["Sheet1"], frozen_row_count)
+    try:
+        payload = (
+            get_service()
+            .spreadsheets()
+            .create(body=body, fields="spreadsheetId,spreadsheetUrl")
+            .execute()
+        )
+    except HttpError as exc:
+        raise handle_http_error(exc) from exc
+    render_output(ctx, payload, "Spreadsheet created")
 
 
 @values_app.command("get", help="读取一个 A1 range 的值。")

--- a/skills/google-sheets-cli/scripts/tests/test_gsheets_cli.py
+++ b/skills/google-sheets-cli/scripts/tests/test_gsheets_cli.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "gsheets_cli.py"
 
 
@@ -37,6 +36,44 @@ def test_values_json_must_be_2d_array():
         cli.ensure_2d_values(["not-a-row"], "--values-json")
 
     assert cli.ensure_2d_values([["ok"]], "--values-json") == [["ok"]]
+
+
+def test_values_json_cells_must_be_scalars():
+    cli = load_cli_module()
+
+    with pytest.raises(cli.CliError, match=r"\[0\]\[1\].*JSON 对象或数组"):
+        cli.ensure_2d_values([["ok", {"$date": "2026-09-01"}]], "--values-json")
+
+
+def test_spreadsheet_create_body_uses_grid_properties_for_frozen_rows():
+    cli = load_cli_module()
+
+    body = cli.spreadsheet_create_body(" Audit ", ["Issues", "Notes"], 1)
+
+    assert body == {
+        "properties": {"title": "Audit"},
+        "sheets": [
+            {
+                "properties": {
+                    "title": "Issues",
+                    "gridProperties": {"frozenRowCount": 1},
+                }
+            },
+            {
+                "properties": {
+                    "title": "Notes",
+                    "gridProperties": {"frozenRowCount": 1},
+                }
+            },
+        ],
+    }
+
+
+def test_spreadsheet_create_body_rejects_duplicate_sheet_titles():
+    cli = load_cli_module()
+
+    with pytest.raises(cli.CliError, match="不能重复"):
+        cli.spreadsheet_create_body("Audit", ["Issues", "Issues"], 0)
 
 
 def test_batch_updates_validate_range_and_values():

--- a/skills/jira-cli/scripts/jira_config.py
+++ b/skills/jira-cli/scripts/jira_config.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import os
 import tempfile
-import tomllib
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
 import tomli_w
+import tomllib
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 DEFAULT_CONFIG_PATH = Path("~/.config/jira-cli/config.toml").expanduser()

--- a/skills/tampermonkey-cli/scripts/tampermonkey.py
+++ b/skills/tampermonkey-cli/scripts/tampermonkey.py
@@ -17,7 +17,7 @@ import json
 import os
 import random
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Self
 
 import typer
 from pydantic import BaseModel
@@ -96,7 +96,7 @@ class TampermonkeyBridge:
         self.next_message_id = 1
         self.ping_task: asyncio.Task[None] | None = None
 
-    async def __aenter__(self) -> TampermonkeyBridge:
+    async def __aenter__(self) -> Self:
         await self.start()
         return self
 
@@ -163,7 +163,7 @@ class TampermonkeyBridge:
                     future.set_result(response if isinstance(response, dict) else data)
         except ConnectionClosed:
             pass
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - 隔离单个 WebSocket 连接错误
             console.print(f"[red]连接处理失败：{exc}[/red]")
         finally:
             if self.connection is websocket:
@@ -182,7 +182,7 @@ class TampermonkeyBridge:
         text = raw_message.decode() if isinstance(raw_message, bytes) else raw_message
         parsed = json.loads(text)
         if not isinstance(parsed, dict):
-            raise ValueError("message must be a JSON object")
+            raise TypeError("message must be a JSON object")
         return parsed
 
     async def command(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -238,9 +238,9 @@ class SocketServer:
             line = await reader.readline()
             request_data = json.loads(line.decode() or "{}")
             if not isinstance(request_data, dict):
-                raise ValueError("request must be a JSON object")
+                raise TypeError("request must be a JSON object")
             response = await self.route(request_data)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - 将控制面错误转换为 JSON 响应
             response = {"ok": False, "error": str(exc)}
 
         writer.write((json.dumps(response, ensure_ascii=False) + "\n").encode())
@@ -302,7 +302,7 @@ async def socket_request(
     await writer.wait_closed()
     response = json.loads(line.decode() or "{}")
     if not isinstance(response, dict):
-        raise RuntimeError("serve returned a non-object response")
+        raise TypeError("serve returned a non-object response")
     return response
 
 
@@ -332,7 +332,7 @@ def command_via_socket(
         raise RuntimeError(str(response.get("error") or response))
     command_response = response.get("response")
     if not isinstance(command_response, dict):
-        raise RuntimeError("serve returned an invalid command response")
+        raise TypeError("serve returned an invalid command response")
     return command_response
 
 

--- a/skills/ticktick-cli/scripts/ticktick_api_client.py
+++ b/skills/ticktick-cli/scripts/ticktick_api_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 import httpxyz
 from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field

--- a/skills/ticktick-cli/scripts/ticktick_auth.py
+++ b/skills/ticktick-cli/scripts/ticktick_auth.py
@@ -4,19 +4,18 @@ import base64
 import hashlib
 import json
 import os
-import socket
 import secrets
+import socket
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 import webbrowser
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
-
 
 DEFAULT_SCOPE = "tasks:read tasks:write"
 ENV_TOKEN_FILE = "TICKTICK_TOKEN_FILE"
@@ -173,7 +172,7 @@ def discover_endpoints(auth_base_url: str) -> AuthEndpoints:
 
 
 def default_client_name() -> str:
-    today = date.today().isoformat()
+    today = datetime.now().astimezone().date().isoformat()
     hostname = socket.gethostname().strip().split(".")[0]
     if not hostname:
         return f"ticktick-cli ({today})"


### PR DESCRIPTION
## Why

- Google Sheets CLI 缺少直接创建 Spreadsheet 的入口，复杂对象值写入失败时也只能得到难以定位的 API 400。
- 仓库没有统一的 Python lint 门禁，Typer 声明式参数还通过整文件 suppression 绕过 `B008`。

## What

- 新增 Spreadsheet 创建命令，支持初始化多个工作表和冻结顶部行；写入前校验单元格 JSON 标量并报告具体位置。
- 增加仓库级 Ruff 配置，精确识别 Typer 参数元数据，修复定义期 `Path.cwd()`、过期写法、无效 suppression 与其它必要告警。
- 在 GitHub Actions 中加入 Ruff format 和 lint 检查，防止告警重新累积。
