### PR TITLE
feat(chatgpt-usage): 展示 Bank Reset 剩余次数与到期时间

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ notification_method = "bel"
   - [`script_deps.py`](scripts/script_deps.py)：检查或升级仓库内 PEP 723 / uv script 依赖声明，对比 PyPI 最新版本，并在 GitHub Actions 中报告依赖下限落后或声明不一致
   - [`upstream_skills.py`](scripts/upstream_skills.py)：根据 [`upstream-skills.toml`](upstream-skills.toml) 检查第三方 skill 的上游目录是否出现新 commit；优先使用 CI 的 `GITHUB_TOKEN`，本地回退到已登录的 `gh`，并在 stderr 输出凭据来源；发现变更或查询失败时返回非 0，并写入 GitHub Actions summary
 
-额度看板会结合 TTY 状态与 Ghostty、Kitty 等终端标识自动选择图片模式；图片渲染失败时自动回退到原有 Rich 文本界面。默认省略低使用频率的 Codex Spark 额度桶，`--verbose` 仍可查看服务端返回的完整额度与本地索引命中情况；额度消耗快于时间进度时，还会提示预计休息多久可以恢复持平。本地用量索引默认保存在系统缓存目录，DuckDB 数据使用 zstd 压缩；归档 rename 只更新路径，未变化的 Thread 不重扫，追加内容只解析新增字节。首次建索引时会在有界线程池中按 Thread 并行扫描，并按固定大小事件批次提交；中断后只重建未完成的 Thread，不会用一个覆盖全部历史的大事务占满内存。`--history-days` 可选择 1–365 天，默认 7 天；缓存覆盖范围只扩不缩，首次请求更长范围时补建一次，之后切回较短范围不会重复扫描。
+额度看板会结合 TTY 状态与 Ghostty、Kitty 等终端标识自动选择图片模式；图片渲染失败时自动回退到原有 Rich 文本界面。默认省略低使用频率的 Codex Spark 额度桶，`--verbose` 仍可查看服务端返回的完整额度与本地索引命中情况；额度消耗快于时间进度时，还会提示预计休息多久可以恢复持平。看板同时展示当前可用的 Bank Reset 次数，以及按到期时间排序的最近 3 个可用 Reset。本地用量索引默认保存在系统缓存目录，DuckDB 数据使用 zstd 压缩；归档 rename 只更新路径，未变化的 Thread 不重扫，追加内容只解析新增字节。首次建索引时会在有界线程池中按 Thread 并行扫描，并按固定大小事件批次提交；中断后只重建未完成的 Thread，不会用一个覆盖全部历史的大事务占满内存。`--history-days` 可选择 1–365 天，默认 7 天；缓存覆盖范围只扩不缩，首次请求更长范围时补建一次，之后切回较短范围不会重复扫描。
 
 金额是根据本地 rollout 中记录的模型、service tier、普通输入、缓存命中、缓存写入和输出 Token，按当前 OpenAI API 单价计算出的等价成本；它用于比较用量价值，不代表 ChatGPT/Codex 订阅的实际账单。脚本优先从 [models.dev](https://models.dev/) 更新价格目录并缓存 24 小时，响应不完整或网络不可用时会依次使用过期缓存和内置价格，因此离线运行不会影响 Token 统计。每次展示时都会用当前价格重算已缓存的逐请求 Token 事实，价格更新不需要重新扫描 rollout；`priority` / Fast 请求在官方已公布价格时会应用对应费率，`--json` 同时区分 Fast 与非 Fast Token。单次请求输入超过 272K Token 时，对已公布长上下文价格的模型按整次请求的长上下文单价估算；未知模型不会套用猜测价格，JSON 输出会保留对应模型明细与未估价 Token 数。
 

--- a/scripts/chatgpt_usage.py
+++ b/scripts/chatgpt_usage.py
@@ -95,6 +95,14 @@ class LimitBucket:
 
 
 @dataclass(frozen=True)
+class ResetCredits:
+    """描述可用的 Bank Reset 次数与最近到期时间。"""
+
+    available_count: int
+    next_expirations_at: tuple[int, ...]
+
+
+@dataclass(frozen=True)
 class WindowProgress:
     """记录额度与时间的可比较剩余进度。"""
 
@@ -440,6 +448,34 @@ def parse_rate_limits(result: dict[str, Any]) -> list[LimitBucket]:
     if not buckets:
         raise UsageError("额度响应中没有可展示的额度桶")
     return buckets
+
+
+def parse_reset_credits(result: dict[str, Any]) -> ResetCredits | None:
+    """解析可用的 Bank Reset，并保留最近三个到期时间。"""
+    value = result.get("rateLimitResetCredits")
+    if not isinstance(value, dict):
+        return None
+
+    credits = value.get("credits")
+    expirations = (
+        sorted(
+            credit["expiresAt"]
+            for credit in credits
+            if isinstance(credit, dict)
+            and credit.get("status") == "available"
+            and isinstance(credit.get("expiresAt"), int)
+            and not isinstance(credit["expiresAt"], bool)
+        )
+        if isinstance(credits, list)
+        else []
+    )
+    available_count = value.get("availableCount")
+    if not isinstance(available_count, int) or isinstance(available_count, bool):
+        available_count = len(expirations)
+    return ResetCredits(
+        available_count=max(0, available_count),
+        next_expirations_at=tuple(expirations[:3]),
+    )
 
 
 def default_codex_home() -> Path:
@@ -1883,6 +1919,28 @@ def _format_cost(estimated_cost_usd: float, unpriced_tokens: int) -> str:
     return f"≈${estimated_cost_usd:.2f}"
 
 
+def _reset_expiration_text(expires_at: int) -> str:
+    """把 Bank Reset 到期时间格式化为本地时间。"""
+    return datetime.fromtimestamp(expires_at).astimezone().strftime("%m-%d %H:%M")
+
+
+def _render_reset_credits(reset_credits: ResetCredits) -> None:
+    """用低调的辅助文字展示 Bank Reset 信息。"""
+    expirations = " · ".join(
+        f"{index}: {_reset_expiration_text(expires_at)}"
+        for index, expires_at in enumerate(reset_credits.next_expirations_at, start=1)
+    )
+    detail = f" · 到期 {expirations}" if expirations else ""
+    line = Text()
+    line.append("● ", style="bright_magenta")
+    line.append("Bank Reset", style="bold")
+    line.append(
+        f" · 剩余 {reset_credits.available_count} 次{detail}",
+        style="dim",
+    )
+    console.print(line)
+
+
 def _render_usage_history(history: UsageHistory, *, verbose: bool) -> None:
     """用 Rich 展示按天 Token 用量与缓存命中率。"""
     table = Table(box=None, padding=(0, 1), show_header=True)
@@ -1938,6 +1996,7 @@ def render_usage(
     now: datetime,
     *,
     history: UsageHistory | None = None,
+    reset_credits: ResetCredits | None = None,
     verbose: bool,
 ) -> None:
     """用 Rich 渲染订阅与额度进度。"""
@@ -2009,6 +2068,8 @@ def render_usage(
                 padding=(0, 1),
             )
         )
+    if reset_credits is not None:
+        _render_reset_credits(reset_credits)
 
 
 def _svg_text(value: object) -> str:
@@ -2167,18 +2228,42 @@ def _usage_history_height(day_count: int) -> int:
     return 76 + rows * 140 + max(0, rows - 1) * 10
 
 
+def _svg_reset_credits(
+    reset_credits: ResetCredits,
+    *,
+    x: float,
+    y: float,
+) -> str:
+    """生成位于看板底部的 Bank Reset 辅助文字。"""
+    expirations = " · ".join(
+        f"{index}: {_reset_expiration_text(expires_at)}"
+        for index, expires_at in enumerate(reset_credits.next_expirations_at, start=1)
+    )
+    detail = f" · 到期 {expirations}" if expirations else ""
+    return f'''<g data-role="reset-credits">
+  <circle cx="{x + 6}" cy="{y + 13}" r="5" fill="#ff79c6" fill-opacity="0.8"/>
+  <text x="{x + 20}" y="{y + 18}" fill="#aebaff" font-size="13" font-weight="700">Bank Reset</text>
+  <text x="{x + 102}" y="{y + 18}" class="muted" font-size="13">· 剩余 {reset_credits.available_count} 次{_svg_text(detail)}</text>
+</g>'''
+
+
 def _render_compact_usage_svg(
-    buckets: list[LimitBucket], now: datetime, history: UsageHistory
+    buckets: list[LimitBucket],
+    now: datetime,
+    history: UsageHistory,
+    reset_credits: ResetCredits | None,
 ) -> str:
     """渲染以每日用量为主、额度摘要为辅的默认看板。"""
     margin = 48
     header_height = 86
     card_gap = 20
     history_height = _usage_history_height(len(history.days))
+    reset_height = 24 if reset_credits is not None else 0
     quota_heights = [70 + 56 * max(1, len(bucket.windows)) for bucket in buckets]
     height = (
         header_height
         + history_height
+        + (card_gap + reset_height if reset_credits is not None else 0)
         + card_gap
         + sum(quota_heights)
         + card_gap * max(0, len(quota_heights) - 1)
@@ -2268,6 +2353,14 @@ def _render_compact_usage_svg(
                 ]
             )
         y += quota_height + card_gap
+    if reset_credits is not None:
+        parts.append(
+            _svg_reset_credits(
+                reset_credits,
+                x=margin,
+                y=y,
+            )
+        )
     parts.append("</svg>\n")
     return "\n".join(parts)
 
@@ -2277,12 +2370,13 @@ def render_usage_svg(
     now: datetime,
     *,
     history: UsageHistory | None = None,
+    reset_credits: ResetCredits | None = None,
     verbose: bool,
 ) -> str:
     """把额度看板渲染为共享刻度对比 SVG。"""
     buckets = _visible_buckets(buckets, verbose=verbose)
     if history is not None and not verbose:
-        return _render_compact_usage_svg(buckets, now, history)
+        return _render_compact_usage_svg(buckets, now, history, reset_credits)
     margin = 48
     card_gap = 24
     panel_gap = 18
@@ -2316,7 +2410,10 @@ def render_usage_svg(
             + 18
         )
     bucket_content_height = (
-        header_height + sum(row_heights) + card_gap * max(0, len(bucket_rows) - 1)
+        header_height
+        + (24 + card_gap if reset_credits is not None else 0)
+        + sum(row_heights)
+        + card_gap * max(0, len(bucket_rows) - 1)
     )
     history_height = (
         _usage_history_height(len(history.days)) if history is not None else 0
@@ -2361,6 +2458,15 @@ def render_usage_svg(
             bucket_layouts.append((bucket, bucket_x, y, bucket_width, row_height))
             bucket_x += bucket_width + card_gap
         y += row_height + card_gap
+
+    if reset_credits is not None:
+        parts.append(
+            _svg_reset_credits(
+                reset_credits,
+                x=margin,
+                y=y,
+            )
+        )
 
     for bucket, bucket_x, y, bucket_width, bucket_height in bucket_layouts:
         accent = "#8be9fd" if bucket.limit_id == "codex" else "#bd93f9"
@@ -2461,11 +2567,18 @@ def render_usage_image(
     now: datetime,
     *,
     history: UsageHistory | None = None,
+    reset_credits: ResetCredits | None = None,
     columns: int | None,
     verbose: bool,
 ) -> None:
     """生成 SVG、栅格化，并通过 Kitty 协议展示。"""
-    svg = render_usage_svg(buckets, now, history=history, verbose=verbose)
+    svg = render_usage_svg(
+        buckets,
+        now,
+        history=history,
+        reset_credits=reset_credits,
+        verbose=verbose,
+    )
     png = svg_to_png(svg)
     render_png(png, cols=columns)
 
@@ -2504,6 +2617,7 @@ def _json_report(
     buckets: list[LimitBucket],
     now: datetime,
     history: UsageHistory | None = None,
+    reset_credits: ResetCredits | None = None,
 ) -> dict[str, Any]:
     """构造稳定的机器可读结果。"""
     rows: list[dict[str, Any]] = []
@@ -2549,6 +2663,17 @@ def _json_report(
     return {
         "fetched_at": now.isoformat(),
         "buckets": rows,
+        "reset_credits": (
+            {
+                "available_count": reset_credits.available_count,
+                "next_expirations_at": [
+                    datetime.fromtimestamp(expires_at).astimezone().isoformat()
+                    for expires_at in reset_credits.next_expirations_at
+                ],
+            }
+            if reset_credits is not None
+            else None
+        ),
         "local_usage": local_usage,
     }
 
@@ -2626,6 +2751,7 @@ def main(
     try:
         result = fetch_rate_limits(resolved, timeout)
         buckets = parse_rate_limits(result)
+        reset_credits = parse_reset_credits(result)
     except UsageError as error:
         error_console.print(f"[bold red]错误：[/]{error}")
         error_console.print("请先确认 Codex CLI 已使用 ChatGPT 账号登录。", style="dim")
@@ -2656,7 +2782,13 @@ def main(
     if save_svg is not None:
         try:
             save_svg.write_text(
-                render_usage_svg(buckets, now, history=history, verbose=verbose),
+                render_usage_svg(
+                    buckets,
+                    now,
+                    history=history,
+                    reset_credits=reset_credits,
+                    verbose=verbose,
+                ),
                 encoding="utf-8",
             )
         except OSError as error:
@@ -2665,7 +2797,14 @@ def main(
     if json_output:
         print(
             json.dumps(
-                _json_report(buckets, now, history), ensure_ascii=False, indent=2
+                _json_report(
+                    buckets,
+                    now,
+                    history,
+                    reset_credits=reset_credits,
+                ),
+                ensure_ascii=False,
+                indent=2,
             )
         )
     elif use_image:
@@ -2677,6 +2816,7 @@ def main(
                 buckets,
                 now,
                 history=history,
+                reset_credits=reset_credits,
                 columns=columns,
                 verbose=verbose,
             )
@@ -2685,9 +2825,21 @@ def main(
                 error_console.print(f"[bold red]错误：[/]无法展示图片：{error}")
                 raise typer.Exit(1) from error
             error_console.print(f"[yellow]图片模式不可用，已回退到文本：[/]{error}")
-            render_usage(buckets, now, history=history, verbose=verbose)
+            render_usage(
+                buckets,
+                now,
+                history=history,
+                reset_credits=reset_credits,
+                verbose=verbose,
+            )
     else:
-        render_usage(buckets, now, history=history, verbose=verbose)
+        render_usage(
+            buckets,
+            now,
+            history=history,
+            reset_credits=reset_credits,
+            verbose=verbose,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -8,7 +8,7 @@
 #     "google-auth-httplib2>=0.4.2",
 #     "google-auth-oauthlib>=1.4.1",
 #     "httpx2>=2.12.0",
-#     "httpxyz>=0.31.2",
+#     "httpxyz>=0.42.0",
 #     "kittytgp>=0.0.2",
 #     "markdown-it-py>=4.2.0",
 #     "openai-codex>=0.147.0",

--- a/scripts/tests/test_chatgpt_usage.py
+++ b/scripts/tests/test_chatgpt_usage.py
@@ -24,6 +24,30 @@ SPEC.loader.exec_module(chatgpt_usage)
 
 
 class ParseRateLimitsTests(unittest.TestCase):
+    def test_parses_available_reset_credits_and_keeps_nearest_three_expirations(
+        self,
+    ) -> None:
+        result = {
+            "rateLimitResetCredits": {
+                "availableCount": 4,
+                "credits": [
+                    {"status": "available", "expiresAt": 2_000_000_400},
+                    {"status": "used", "expiresAt": 2_000_000_050},
+                    {"status": "available", "expiresAt": 2_000_000_300},
+                    {"status": "available", "expiresAt": 2_000_000_100},
+                    {"status": "available", "expiresAt": 2_000_000_200},
+                ],
+            }
+        }
+
+        reset_credits = chatgpt_usage.parse_reset_credits(result)
+
+        self.assertEqual(reset_credits.available_count, 4)
+        self.assertEqual(
+            reset_credits.next_expirations_at,
+            (2_000_000_100, 2_000_000_200, 2_000_000_300),
+        )
+
     def test_parses_all_buckets_without_duplicating_top_level_bucket(self) -> None:
         result = {
             "rateLimits": {
@@ -155,6 +179,62 @@ class RenderUsageTests(unittest.TestCase):
         self.assertIn("时间", output)
         self.assertIn("偏慢 +25.0pp", output)
         self.assertNotIn("codex_internal", output)
+
+    def test_outputs_reset_credit_count_and_next_expirations_everywhere(self) -> None:
+        reset_credits = chatgpt_usage.ResetCredits(
+            available_count=2,
+            next_expirations_at=(
+                int(datetime(2030, 1, 2, 12, tzinfo=UTC).timestamp()),
+                int(datetime(2030, 1, 3, 18, 30, tzinfo=UTC).timestamp()),
+            ),
+        )
+
+        chatgpt_usage.render_usage(
+            self.buckets,
+            self.now,
+            reset_credits=reset_credits,
+            verbose=False,
+        )
+        svg = chatgpt_usage.render_usage_svg(
+            self.buckets,
+            self.now,
+            reset_credits=reset_credits,
+            verbose=False,
+        )
+        report = chatgpt_usage._json_report(
+            self.buckets,
+            self.now,
+            reset_credits=reset_credits,
+        )
+
+        output = self.output.getvalue()
+        self.assertIn("Bank Reset", output)
+        self.assertIn("● Bank Reset", output)
+        self.assertIn("剩余 2 次", output)
+        first_expiration = chatgpt_usage._reset_expiration_text(
+            reset_credits.next_expirations_at[0]
+        )
+        second_expiration = chatgpt_usage._reset_expiration_text(
+            reset_credits.next_expirations_at[1]
+        )
+        self.assertIn(first_expiration, output)
+        self.assertIn(second_expiration, output)
+        self.assertIn('data-role="reset-credits"', svg)
+        self.assertNotIn('data-role="reset-credits" filter=', svg)
+        reset_markup = svg.split('data-role="reset-credits"', 1)[1].split("</g>", 1)[0]
+        self.assertIn("<circle", reset_markup)
+        self.assertNotIn('text-anchor="end"', reset_markup)
+        self.assertIn("剩余 2 次", svg)
+        self.assertIn(first_expiration, svg)
+        self.assertIn(second_expiration, svg)
+        self.assertEqual(report["reset_credits"]["available_count"], 2)
+        self.assertEqual(
+            report["reset_credits"]["next_expirations_at"],
+            [
+                datetime.fromtimestamp(expires_at).astimezone().isoformat()
+                for expires_at in reset_credits.next_expirations_at
+            ],
+        )
 
     def test_verbose_output_restores_diagnostic_details(self) -> None:
         chatgpt_usage.render_usage(self.buckets, self.now, verbose=True)

--- a/skills/confluence-cli/scripts/confluence_cli.py
+++ b/skills/confluence-cli/scripts/confluence_cli.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "httpxyz>=0.31.2",
+#     "httpxyz>=0.42.0",
 #     "markdown-it-py>=4.2.0",
 #     "pydantic>=2.13.5",
 #     "rich>=15.0.0",

--- a/skills/ticktick-cli/scripts/ticktick_cli.py
+++ b/skills/ticktick-cli/scripts/ticktick_cli.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "httpxyz>=0.31.2",
+#     "httpxyz>=0.42.0",
 #     "typer>=0.27.2",
 #     "pydantic>=2.13.5",
 #     "rich>=15.0.0",


### PR DESCRIPTION
## Why

现有用量看板缺少 Bank Reset 的可用次数与到期信息，无法直接判断额度耗尽后的补充保障。

## What

- 解析服务端返回的可用 Bank Reset，展示剩余次数及最近 3 个到期时间。
- 在文本和图片看板底部以左对齐的弱化提示呈现，保留额度窗口的视觉主次。
- 在 JSON 输出中补充结构化 Reset 信息，并覆盖解析、文本与 SVG 输出契约。
- 将 3 个 PEP 723 脚本的 `httpxyz` 最低版本更新至 `0.42.0`，恢复依赖版本检查。
