### PR TITLE
feat(telegram): 通过 HTTPS bridge 打开 Codex 会话

### DIFF
--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -85,7 +85,7 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram Rich Message 的显式 `blocks`：任务标题使用小号 heading，最终结论放入 blockquote；仅在提供 `action` 时增加高亮的“需要你处理”段落；最后用单行 footer 紧凑显示状态、验证和上下文。不要添加泛化通知标题、分隔线或逐字段 Emoji。所有输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`：任务标题使用小号 heading，最终结论放入 blockquote；仅在提供 `action` 时增加高亮的“需要你处理”段落；最后用单行 footer 紧凑显示状态、验证和上下文。Codex 运行时提供合法的 `CODEX_SESSION_ID` 时，footer 末尾还会自动添加可见、可点击的 `codex://threads/<session-id>`；Codex 把它定义为当前 agent tree 的根 thread ID，所以 subagent 通知返回根 Agent，普通 fork 成为新根后则指向 fork 出的新 thread。变量缺失或格式无效时省略链接，不要回退到 subagent 自己的 `CODEX_THREAD_ID`。不要添加泛化通知标题、分隔线或逐字段 Emoji。所有命令行输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
 
 `preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 

--- a/skills/notify-via-telegram/SKILL.md
+++ b/skills/notify-via-telegram/SKILL.md
@@ -85,7 +85,7 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
   --summary "最终结果的一句话摘要"
 ```
 
-脚本统一生成 Telegram Rich Message 的显式 `blocks`：任务标题使用小号 heading，最终结论放入 blockquote；仅在提供 `action` 时增加高亮的“需要你处理”段落；最后用单行 footer 紧凑显示状态、验证和上下文。Codex 运行时提供合法的 `CODEX_SESSION_ID` 时，footer 末尾还会自动添加可见、可点击的 `codex://threads/<session-id>`；Codex 把它定义为当前 agent tree 的根 thread ID，所以 subagent 通知返回根 Agent，普通 fork 成为新根后则指向 fork 出的新 thread。变量缺失或格式无效时省略链接，不要回退到 subagent 自己的 `CODEX_THREAD_ID`。不要添加泛化通知标题、分隔线或逐字段 Emoji。所有命令行输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
+脚本统一生成 Telegram Rich Message 的显式 `blocks`：任务标题使用小号 heading，最终结论放入 blockquote；仅在提供 `action` 时增加高亮的“需要你处理”段落；最后用单行 footer 紧凑显示状态、验证和上下文。Codex 运行时提供合法的 `CODEX_SESSION_ID` 时，footer 末尾还会自动添加“打开 Codex 会话：”和完整 HTTPS URL。该链接经过配套 Cloudflare Worker 转为 `codex://threads/<session-id>`，绕过 Telegram 不支持自定义 URL 协议的问题。完整 URL 必须作为普通文本交由 Telegram 自动识别，不要改成隐藏目标的 URL 文字或按钮：Telegram 客户端会对这两种 inline link 强制弹出“Open this link?”确认。Codex 把 `CODEX_SESSION_ID` 定义为当前 agent tree 的根 thread ID，所以 subagent 通知返回根 Agent，普通 fork 成为新根后则指向 fork 出的新 thread。变量缺失或格式无效时省略链接，不要回退到 subagent 自己的 `CODEX_THREAD_ID`。不要添加泛化通知标题、分隔线或逐字段 Emoji。所有命令行输入字段都作为纯文本 RichText 传递；不要自行添加 Telegram HTML、Markdown 或 RichText 结构。
 
 `preview --json` 返回与发送请求一致的 `rich_message` 对象，可在不读取配置、不访问 Telegram 的情况下检查内容块。格式能力与字段定义以 Telegram 官方的 [Rich Messages](https://core.telegram.org/bots/features#rich-messages) 和 [Bot API](https://core.telegram.org/bots/api#sendrichmessage) 文档为准。
 
@@ -109,3 +109,15 @@ Agent 调用时使用 `--json`，并把全局参数放在子命令前。
 - 配置缺失时，告诉用户应执行哪些配置命令；不要替用户猜测 Token 或 Chat ID。
 
 发送成功后读取 JSON 中的 `message_id`。发送失败时，把通知失败与原任务结果分开报告，不要因此改变原任务的最终状态。
+
+## 深链 bridge
+
+配套 Worker 位于 [worker](worker)，生产地址为 `https://codex-thread-bridge.dcjanus.workers.dev`。它只接受 `/codex/open-thread/<UUID>`，并直接返回指向对应 `codex://threads/<UUID>` 的 `302`；无效路径返回 `404`，因此不能被用作任意 URL 的开放重定向器。重定向响应允许浏览器缓存 1 天，以减少同一链接重复点击产生的 Worker 请求。Cloudflare Static Assets 的重定向规则不允许 `codex://` 目标，因此该 bridge 必须执行一段最小 Worker 脚本；每个未命中浏览器缓存的点击会产生一次 Worker 请求。
+
+在本 skill 目录下执行以下命令可验证和部署 Worker：
+
+```bash
+node --test worker/test/index.test.mjs
+wrangler deploy --dry-run --config worker/wrangler.jsonc
+wrangler deploy --config worker/wrangler.jsonc
+```

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -32,7 +32,9 @@ from rich.table import Table
 
 CONFIG_ENV = "NOTIFY_VIA_TELEGRAM_CONFIG"
 CODEX_SESSION_ID_ENV = "CODEX_SESSION_ID"
-CODEX_THREAD_URL_PREFIX = "codex://threads/"
+CODEX_THREAD_BRIDGE_URL_PREFIX = (
+    "https://codex-thread-bridge.dcjanus.workers.dev/codex/open-thread/"
+)
 DEFAULT_TIMEOUT_SECONDS = 10.0
 TELEGRAM_API_BASE = "https://api.telegram.org"
 
@@ -134,7 +136,7 @@ def notification_from_options(
 
 
 def current_codex_root_thread_url() -> str | None:
-    """从 Codex 根 session ID 构造当前 agent tree 的桌面端深链。"""
+    """从 Codex 根 session ID 构造 Telegram 可点击的 HTTPS bridge 链接。"""
 
     thread_id = os.environ.get(CODEX_SESSION_ID_ENV, "").strip()
     if not thread_id:
@@ -146,7 +148,7 @@ def current_codex_root_thread_url() -> str | None:
         return None
     if canonical_thread_id != thread_id.lower():
         return None
-    return f"{CODEX_THREAD_URL_PREFIX}{canonical_thread_id}"
+    return f"{CODEX_THREAD_BRIDGE_URL_PREFIX}{canonical_thread_id}"
 
 
 def render_notification_blocks(notification: Notification) -> list[dict[str, Any]]:
@@ -184,12 +186,8 @@ def render_notification_blocks(notification: Notification) -> list[dict[str, Any
     if notification.codex_thread_url:
         footer.extend(
             [
-                " · ",
-                {
-                    "type": "url",
-                    "text": notification.codex_thread_url,
-                    "url": notification.codex_thread_url,
-                },
+                " · 打开 Codex 会话：",
+                notification.codex_thread_url,
             ]
         )
     blocks.append({"type": "footer", "text": footer})
@@ -452,7 +450,7 @@ def preview_message(
             "",
         )
         return
-    console.print(render_notification_plain(notification), markup=False)
+    console.print(render_notification_plain(notification), markup=False, soft_wrap=True)
 
 
 @config_app.command("path")

--- a/skills/notify-via-telegram/scripts/notify.py
+++ b/skills/notify-via-telegram/scripts/notify.py
@@ -20,6 +20,7 @@ import tempfile
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any
+from uuid import UUID
 
 import httpx2
 import tomli_w
@@ -30,6 +31,8 @@ from rich.console import Console
 from rich.table import Table
 
 CONFIG_ENV = "NOTIFY_VIA_TELEGRAM_CONFIG"
+CODEX_SESSION_ID_ENV = "CODEX_SESSION_ID"
+CODEX_THREAD_URL_PREFIX = "codex://threads/"
 DEFAULT_TIMEOUT_SECONDS = 10.0
 TELEGRAM_API_BASE = "https://api.telegram.org"
 
@@ -82,6 +85,7 @@ class Notification(BaseModel):
     verification: str | None = Field(default=None, min_length=1, max_length=200)
     action: str | None = Field(default=None, min_length=1, max_length=200)
     context: str | None = Field(default=None, min_length=1, max_length=80)
+    codex_thread_url: str | None = None
 
     @field_validator(
         "title", "summary", "verification", "action", "context", mode="before"
@@ -119,6 +123,7 @@ def notification_from_options(
             verification=verification,
             action=action,
             context=context,
+            codex_thread_url=current_codex_root_thread_url(),
         )
     except ValidationError as exc:
         details = ", ".join(
@@ -126,6 +131,22 @@ def notification_from_options(
             for error in exc.errors(include_input=False)
         )
         abort(f"通知内容无效：{details}")
+
+
+def current_codex_root_thread_url() -> str | None:
+    """从 Codex 根 session ID 构造当前 agent tree 的桌面端深链。"""
+
+    thread_id = os.environ.get(CODEX_SESSION_ID_ENV, "").strip()
+    if not thread_id:
+        return None
+
+    try:
+        canonical_thread_id = str(UUID(thread_id))
+    except ValueError:
+        return None
+    if canonical_thread_id != thread_id.lower():
+        return None
+    return f"{CODEX_THREAD_URL_PREFIX}{canonical_thread_id}"
 
 
 def render_notification_blocks(notification: Notification) -> list[dict[str, Any]]:
@@ -160,6 +181,17 @@ def render_notification_blocks(notification: Notification) -> list[dict[str, Any
         footer.extend([" · ", notification.verification])
     if notification.context:
         footer.extend([" · ", notification.context])
+    if notification.codex_thread_url:
+        footer.extend(
+            [
+                " · ",
+                {
+                    "type": "url",
+                    "text": notification.codex_thread_url,
+                    "url": notification.codex_thread_url,
+                },
+            ]
+        )
     blocks.append({"type": "footer", "text": footer})
     return blocks
 
@@ -181,6 +213,8 @@ def render_notification_plain(notification: Notification) -> str:
         footer.append(notification.verification)
     if notification.context:
         footer.append(notification.context)
+    if notification.codex_thread_url:
+        footer.append(notification.codex_thread_url)
     lines.extend(["", " · ".join(footer)])
     return "\n".join(lines)
 

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -6,6 +6,7 @@ import secrets
 import sys
 from pathlib import Path
 
+import pytest
 import tomllib
 from typer.testing import CliRunner
 
@@ -16,6 +17,12 @@ notify = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 sys.modules[SPEC.name] = notify
 SPEC.loader.exec_module(notify)
+
+
+@pytest.fixture(autouse=True)
+def clear_codex_context_ids(monkeypatch) -> None:
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+    monkeypatch.delenv("CODEX_SESSION_ID", raising=False)
 
 
 def test_config_set_accepts_negative_chat_id(tmp_path: Path) -> None:
@@ -71,6 +78,90 @@ def test_render_notification_blocks_create_clear_visual_hierarchy() -> None:
             "text": ["✅ 已完成", " · ", "157 > 0", " · ", "prompts"],
         },
     ]
+
+
+def test_json_preview_links_subagent_notification_to_root_thread(monkeypatch) -> None:
+    root_thread_id = "01a06b36-0123-7850-9299-04b3f86609d8"
+    child_thread_id = "01a06b65-a6b1-7672-8959-961d8d130f66"
+    monkeypatch.setenv("CODEX_SESSION_ID", root_thread_id)
+    monkeypatch.setenv("CODEX_THREAD_ID", child_thread_id)
+
+    result = CliRunner().invoke(
+        notify.app,
+        [
+            "--json",
+            "preview",
+            "--status",
+            "success",
+            "--title",
+            "任务完成",
+            "--summary",
+            "已经完成。",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["rich_message"]["blocks"][-1] == {
+        "type": "footer",
+        "text": [
+            "✅ 已完成",
+            " · ",
+            {
+                "type": "url",
+                "text": f"codex://threads/{root_thread_id}",
+                "url": f"codex://threads/{root_thread_id}",
+            },
+        ],
+    }
+
+
+def test_plain_preview_links_fork_to_its_new_root_thread(monkeypatch) -> None:
+    forked_thread_id = "01a06c1a-a61c-7c84-a701-2b5c2aca2225"
+    monkeypatch.setenv("CODEX_SESSION_ID", forked_thread_id)
+    monkeypatch.setenv("CODEX_THREAD_ID", forked_thread_id)
+
+    result = CliRunner().invoke(
+        notify.app,
+        [
+            "preview",
+            "--status",
+            "success",
+            "--title",
+            "任务完成",
+            "--summary",
+            "已经完成。",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.endswith(f"codex://threads/{forked_thread_id}\n")
+
+
+@pytest.mark.parametrize("session_id", [None, "", "not-a-thread-id"])
+def test_plain_preview_omits_codex_link_without_valid_session_id(
+    monkeypatch, session_id: str | None
+) -> None:
+    if session_id is None:
+        monkeypatch.delenv("CODEX_SESSION_ID", raising=False)
+    else:
+        monkeypatch.setenv("CODEX_SESSION_ID", session_id)
+
+    result = CliRunner().invoke(
+        notify.app,
+        [
+            "preview",
+            "--status",
+            "success",
+            "--title",
+            "任务完成",
+            "--summary",
+            "已经完成。",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "codex://threads/" not in result.output
 
 
 def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) -> None:

--- a/skills/notify-via-telegram/scripts/tests/test_notify.py
+++ b/skills/notify-via-telegram/scripts/tests/test_notify.py
@@ -106,12 +106,11 @@ def test_json_preview_links_subagent_notification_to_root_thread(monkeypatch) ->
         "type": "footer",
         "text": [
             "✅ 已完成",
-            " · ",
-            {
-                "type": "url",
-                "text": f"codex://threads/{root_thread_id}",
-                "url": f"codex://threads/{root_thread_id}",
-            },
+            " · 打开 Codex 会话：",
+            (
+                "https://codex-thread-bridge.dcjanus.workers.dev/codex/open-thread/"
+                f"{root_thread_id}"
+            ),
         ],
     }
 
@@ -135,7 +134,10 @@ def test_plain_preview_links_fork_to_its_new_root_thread(monkeypatch) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert result.output.endswith(f"codex://threads/{forked_thread_id}\n")
+    assert result.output.endswith(
+        "https://codex-thread-bridge.dcjanus.workers.dev/codex/open-thread/"
+        f"{forked_thread_id}\n"
+    )
 
 
 @pytest.mark.parametrize("session_id", [None, "", "not-a-thread-id"])
@@ -161,7 +163,10 @@ def test_plain_preview_omits_codex_link_without_valid_session_id(
     )
 
     assert result.exit_code == 0, result.output
-    assert "codex://threads/" not in result.output
+    assert (
+        "codex-thread-bridge.dcjanus.workers.dev/codex/open-thread/"
+        not in result.output
+    )
 
 
 def test_send_uses_structured_rich_message_payload(monkeypatch, tmp_path: Path) -> None:

--- a/skills/notify-via-telegram/worker/src/index.mjs
+++ b/skills/notify-via-telegram/worker/src/index.mjs
@@ -1,0 +1,37 @@
+const THREAD_PATH_PATTERN =
+	/^\/codex\/open-thread\/([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\/?$/i;
+
+export function codexThreadDeepLink(pathname) {
+	const match = pathname.match(THREAD_PATH_PATTERN);
+	return match ? `codex://threads/${match[1].toLowerCase()}` : null;
+}
+
+export function handleRequest(request) {
+	if (request.method !== "GET" && request.method !== "HEAD") {
+		return new Response("Method Not Allowed", {
+			status: 405,
+			headers: { Allow: "GET, HEAD" },
+		});
+	}
+
+	const deepLink = codexThreadDeepLink(new URL(request.url).pathname);
+	if (!deepLink) {
+		return new Response("Not Found", { status: 404 });
+	}
+
+	return new Response(null, {
+		status: 302,
+		headers: {
+			"Cache-Control": "public, max-age=86400, immutable",
+			Location: deepLink,
+			"Referrer-Policy": "no-referrer",
+			"X-Content-Type-Options": "nosniff",
+		},
+	});
+}
+
+export default {
+	fetch(request) {
+		return handleRequest(request);
+	},
+};

--- a/skills/notify-via-telegram/worker/test/index.test.mjs
+++ b/skills/notify-via-telegram/worker/test/index.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { codexThreadDeepLink, handleRequest } from "../src/index.mjs";
+
+const THREAD_ID = "01a06b65-a6b1-7672-8959-961d8d130f66";
+
+test("valid thread path opens only the corresponding Codex deep link", () => {
+	assert.equal(
+		codexThreadDeepLink(`/codex/open-thread/${THREAD_ID}`),
+		`codex://threads/${THREAD_ID}`,
+	);
+});
+
+test("thread IDs are canonicalized to lowercase", () => {
+	assert.equal(
+		codexThreadDeepLink(`/codex/open-thread/${THREAD_ID.toUpperCase()}/`),
+		`codex://threads/${THREAD_ID}`,
+	);
+});
+
+test("arbitrary redirects and malformed thread IDs are rejected", () => {
+	for (const path of [
+		"/",
+		`/threads/${THREAD_ID}`,
+		"/codex/open-thread/not-a-uuid",
+		`/codex/open-thread/${THREAD_ID}/https://example.com`,
+	]) {
+		assert.equal(codexThreadDeepLink(path), null, path);
+	}
+});
+
+test("valid bridge responses redirect and carry browser cache headers", () => {
+	const response = handleRequest(
+		new Request(`https://example.com/codex/open-thread/${THREAD_ID}`),
+	);
+
+	assert.equal(response.status, 302);
+	assert.equal(response.headers.get("location"), `codex://threads/${THREAD_ID}`);
+	assert.equal(
+		response.headers.get("cache-control"),
+		"public, max-age=86400, immutable",
+	);
+});
+
+test("unsupported methods and invalid paths are rejected", () => {
+	assert.equal(
+		handleRequest(
+			new Request(`https://example.com/codex/open-thread/${THREAD_ID}`, {
+				method: "POST",
+			}),
+		).status,
+		405,
+	);
+	assert.equal(handleRequest(new Request("https://example.com/nope")).status, 404);
+});

--- a/skills/notify-via-telegram/worker/wrangler.jsonc
+++ b/skills/notify-via-telegram/worker/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+	"name": "codex-thread-bridge",
+	"main": "src/index.mjs",
+	"compatibility_date": "2026-09-04",
+	"workers_dev": true,
+	"preview_urls": false,
+	"observability": {
+		"enabled": true
+	}
+}


### PR DESCRIPTION
## 背景

Telegram 不会把 `codex://` 自定义协议稳定渲染成可点击链接；将 HTTPS 隐藏在链接文字或按钮后，又会触发客户端的 “Open this link?” 安全确认。通知需要提供一个无需在 Telegram 内二次确认、并能跳回对应 Codex 会话的入口。

## 改动

- 从 Codex 注入的 `CODEX_SESSION_ID` 构造会话地址：subagent 沿用根 Agent，普通 fork 则以新 thread 作为新根
- 在 Rich Message footer 中展示完整可见的 HTTPS URL，让 Telegram 自动识别普通 URL，避免隐藏链接安全确认
- 新增最小 Cloudflare Worker `codex-thread-bridge`，仅接受 `/codex/open-thread/<UUID>`，返回对应 `codex://threads/<UUID>` 的 `302`
- 严格校验 UUID，无效路径返回 `404`，避免成为开放重定向器
- 重定向响应设置 1 天浏览器缓存，减少同一链接重复点击产生的 Worker 请求

## 关于链接预览

当前通知使用 `sendRichMessage`；Telegram Bot API 没有为该方法提供 `link_preview_options`。改成 URL 按钮仍会触发安全确认，因此本 PR 保留完整可见 URL，不引入预览卡片或第二个按钮。

## 验证

- 全仓库 Python 测试：195 passed
- Telegram 定向测试：10 passed
- Worker Node 测试：5 passed
- `ruff format --check`、`ruff check`、`git diff --check` 通过
- `wrangler deploy --dry-run` 通过
- 线上 Worker：合法路径返回带缓存头的 `302`，无效路径返回 `404`
- Telegram 实发消息 `message_id=161`：点击完整 URL 时未出现 Telegram 安全确认，并直接交给 Codex 打开对应会话

## 部署与成本

- Worker 已部署到 `https://codex-thread-bridge.dcjanus.workers.dev`
- Cloudflare Static Assets 的重定向规则不允许 `codex://` 目标，因此保留最小动态 Worker
- 每个未命中浏览器缓存的点击产生一次 Worker 请求；重复点击可复用 1 天缓存
