### PR TITLE
feat(google-calendar-cli): 新增 Google Calendar 交互技能

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ notification_method = "bel"
 | [`domain-modeling`](skills/domain-modeling/SKILL.md) | 构建并持续校准领域模型，明确领域术语与边界，并在必要时记录重要架构决策。 |
 | [`fetch-url`](skills/fetch-url/SKILL.md) | 获取并提取链接正文（默认 Markdown）；内置 X/Twitter URL 处理，提升受限页面的抓取成功率。 |
 | [`google-mail-cli`](skills/google-mail-cli/SKILL.md) | 使用 Gmail API 搜索和读取邮件、整理标签、管理草稿、发送邮件及配置过滤规则。 |
+| [`google-calendar-cli`](skills/google-calendar-cli/SKILL.md) | 使用 Google Calendar API 查看日历和事件、查询空闲忙碌时间，以及创建、更新或删除事件。 |
 | [`review-fix-loop`](skills/review-fix-loop/SKILL.md) | 用三个相互隔离的干净 subagent 并行做代码审查，由主 agent 判断审查意见价值、修复有效问题并提交推送，直到同一批三个 reviewer 都没有有价值审查意见；仅在显式调用时启用。 |
 | [`repository-workflow`](skills/repository-workflow/SKILL.md) | 处理从本地 Git 变更到 GitHub/GitLab 协作发布的完整流程，包括语义化提交、Issue/PR/MR 文案与 inline review reply。 |
 | [`github-cli`](skills/github-cli/SKILL.md) | GitHub CLI 使用指引，面向 GitHub 资源交互（如 repo、issue、PR、comment、release、workflow） |

--- a/skills/google-calendar-cli/SKILL.md
+++ b/skills/google-calendar-cli/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: google-calendar-cli
+description: 使用 Python CLI 与 Google Calendar API 交互以查看日历和事件、查询空闲忙碌时间、创建、更新或删除事件；适用于用户明确要求操作自己的 Google 日历时，不用于其它日历服务。
+---
+
+# google-calendar-cli
+
+通过本 skill 调用 Google Calendar API。读取日程时只取当前任务需要的日历与时间范围，不要把无关事件详情、参会人或会议链接带入上下文。
+
+## 执行约定
+
+以下命令均以当前 `SKILL.md` 所在文件夹为 workdir。支持 `env -S` 时直接执行：
+
+```bash
+cd skills/google-calendar-cli && ./scripts/google_calendar_cli.py --json events list \
+  --calendar-id primary \
+  --time-min '2026-09-04T00:00:00+08:00' \
+  --time-max '2026-09-05T00:00:00+08:00'
+```
+
+不支持 `env -S` 时使用：
+
+```bash
+cd skills/google-calendar-cli && uv run --script scripts/google_calendar_cli.py --json events list \
+  --calendar-id primary \
+  --time-min '2026-09-04T00:00:00+08:00' \
+  --time-max '2026-09-05T00:00:00+08:00'
+```
+
+- 不要用 `uv run python` 或 `python` 调用脚本。
+- 给 Agent 解析的输出一律加 `--json`，且全局参数必须放在子命令前。
+- 参数不确定时先运行 `./scripts/google_calendar_cli.py <command> --help`。
+- 写操作只在用户明确要求时执行；范围、日历 ID 或事件 ID 不确定时先读。
+
+## 认证
+
+先运行：
+
+```bash
+./scripts/google_calendar_cli.py --json auth doctor
+```
+
+CLI 可以复用现有 Google Workspace / Sheets Desktop OAuth Client，但 Calendar token 始终单独保存在 `$XDG_CONFIG_HOME/google-calendar-cli/token.json`。缺少 client secret、Calendar API 未启用、scope 未配置或 Workspace 策略阻止时，读取 [google-workspace-oauth.md](references/google-workspace-oauth.md)。
+
+## 安全边界
+
+- 创建、更新、删除事件前，先展示目标 calendar ID、事件 ID（如有）、主要字段、参会人、重复规则和通知范围；得到明确授权后分别添加 `--confirm-create`、`--confirm-update`、`--confirm-delete`。
+- `--send-updates` 默认 `none`，不会主动发参会人邮件。只有用户明确要求通知时才使用 `all` 或 `externalOnly`；即使选择 `none`，Google 仍可能在部分场景发送必要通知。
+- 修改或删除重复日程前，先区分事件系列 ID 和具体 instance ID。修改单个实例会创建 exception；不要用逐实例修改代替整个系列更新。
+- `events patch` 是局部更新，但 JSON 数组字段会整体替换。更新 attendees、recurrence、reminders 等数组前先 `events get` 并保留需要的元素。
+- 写入成功后，用响应中的 event ID 再执行一次 `events get` 回读；删除后记录 API 成功结果和准确 event ID。
+- 不申请完整 `calendar` scope，不提供修改 ACL、共享设置、清空主日历或删除整个日历的能力。
+- 不要输出 OAuth client secret、access token、refresh token，或把这些文件带入 Agent 上下文。
+
+## 常用命令
+
+命令族：
+
+- `auth login|doctor|logout|paths`
+- `calendars list|get`
+- `events list|get|instances|create|patch|delete`
+- `freebusy query`
+
+列出日历与事件：
+
+```bash
+./scripts/google_calendar_cli.py --json calendars list
+./scripts/google_calendar_cli.py --json events list \
+  --calendar-id primary \
+  --time-min '2026-09-04T00:00:00+08:00' \
+  --time-max '2026-09-11T00:00:00+08:00' \
+  --query '项目同步'
+```
+
+查询多人空闲时间：
+
+```bash
+./scripts/google_calendar_cli.py --json freebusy query \
+  --calendar-id 'first@example.com' \
+  --calendar-id 'second@example.com' \
+  --time-min '2026-09-04T09:00:00+08:00' \
+  --time-max '2026-09-04T18:00:00+08:00' \
+  --time-zone 'Asia/Shanghai'
+```
+
+创建普通事件。`start.dateTime` / `end.dateTime` 应包含 RFC3339 时区偏移；不带偏移时必须在对应对象内提供 IANA `timeZone`。全天事件改用 `date`，且 `end.date` 是不包含在事件内的结束日期：
+
+```bash
+./scripts/google_calendar_cli.py --json events create \
+  --calendar-id primary \
+  --event-json '{"summary":"项目同步","start":{"dateTime":"2026-09-05T10:00:00+08:00"},"end":{"dateTime":"2026-09-05T10:30:00+08:00"}}' \
+  --confirm-create
+```
+
+带参会人与重复规则的复杂事件优先使用临时 JSON 文件：
+
+```bash
+./scripts/google_calendar_cli.py --json events create \
+  --calendar-id primary \
+  --event-json @/tmp/calendar-event.json \
+  --send-updates all \
+  --confirm-create \
+  && rm -- /tmp/calendar-event.json
+```
+
+只有当 JSON 文件由 Agent 为本次操作临时创建、写入成功后不再需要验证或回滚时，才能按上例用 `&& rm -- <明确路径>` 清理。失败时保留文件；不要使用 `;`、变量、通配符或目录作为清理目标，也不要删除用户提供的文件。
+
+更新前先读取事件，再传递局部 patch：
+
+```bash
+./scripts/google_calendar_cli.py --json events get \
+  --calendar-id primary --event-id <event-id>
+./scripts/google_calendar_cli.py --json events patch \
+  --calendar-id primary \
+  --event-id <event-id> \
+  --event-json '{"summary":"新的标题"}' \
+  --confirm-update
+```
+
+查看重复事件实例：
+
+```bash
+./scripts/google_calendar_cli.py --json events instances \
+  --calendar-id primary \
+  --event-id <recurring-event-id> \
+  --time-min '2026-09-01T00:00:00+08:00' \
+  --time-max '2026-10-01T00:00:00+08:00'
+```
+
+## 权限范围
+
+CLI 只请求：
+
+- `calendar.calendarlist.readonly`：读取用户已订阅的日历列表和元数据。
+- `calendar.events`：读取和管理用户有权访问的事件。
+- `calendar.events.freebusy`：读取用户有权查询的忙碌时间。
+
+这些权限不包含修改日历共享 ACL、删除整个日历或清空主日历。
+
+## 参考
+
+- [google_calendar_cli.py](scripts/google_calendar_cli.py)
+- [google-workspace-oauth.md](references/google-workspace-oauth.md)
+- [Google Calendar API](https://developers.google.com/workspace/calendar/api/v3/reference)
+- [Google Calendar API scopes](https://developers.google.com/workspace/calendar/api/auth)
+- [Recurring events](https://developers.google.com/workspace/calendar/api/guides/recurringevents)

--- a/skills/google-calendar-cli/agents/openai.yaml
+++ b/skills/google-calendar-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Google Calendar CLI"
+  short_description: "通过 Google Calendar API 安全管理日程"
+  default_prompt: "Use $google-calendar-cli to inspect my schedule and create an event after I confirm the details."

--- a/skills/google-calendar-cli/references/google-workspace-oauth.md
+++ b/skills/google-calendar-cli/references/google-workspace-oauth.md
@@ -1,0 +1,83 @@
+# Google Calendar CLI 的 Google Workspace OAuth 配置
+
+只在首次配置或认证报错时读取本文。
+
+## 凭据与 token
+
+CLI 按以下顺序寻找 OAuth Desktop client secret：
+
+1. 环境变量 `GOOGLE_WORKSPACE_CLIENT_SECRET` 指向的文件。
+2. `$XDG_CONFIG_HOME/google-workspace-cli/client_secret.json`。
+3. `$XDG_CONFIG_HOME/google-sheets-cli/client_secret.json`，用于直接复用现有 Sheets CLI 的 OAuth Client。
+
+未设置 `XDG_CONFIG_HOME` 时使用 `~/.config`。Google Calendar refresh token 始终单独保存在：
+
+```text
+$XDG_CONFIG_HOME/google-calendar-cli/token.json
+```
+
+不要复制 Google Sheets 或 Google Mail 的 `token.json`；它们包含不同 scopes。Desktop app 不支持增量授权，Calendar CLI 必须单独运行一次完整登录。
+
+CLI 创建配置目录时设置权限为 `0700`，并以临时文件加原子替换的方式把 token 保存为 `0600`。环境变量只应保存 client secret 的文件路径，不要直接保存 JSON 内容。
+
+## Google Cloud 配置
+
+可以继续使用现有 Google Cloud Project 和 Desktop OAuth Client ID：
+
+1. 在同一 Project 中启用 Google Calendar API。
+2. 在 Google Auth Platform 的 Data Access 中加入：
+   - `https://www.googleapis.com/auth/calendar.calendarlist.readonly`
+   - `https://www.googleapis.com/auth/calendar.events`
+   - `https://www.googleapis.com/auth/calendar.events.freebusy`
+3. 保持 OAuth Client 类型为 `Desktop app`。
+4. Workspace 组织如启用了 API Controls，请让管理员允许该 Client ID 使用上述 scopes。
+
+然后执行：
+
+```bash
+cd skills/google-calendar-cli
+./scripts/google_calendar_cli.py auth login
+./scripts/google_calendar_cli.py --json auth doctor
+```
+
+本 CLI 不请求完整的 `https://www.googleapis.com/auth/calendar`，因此不能管理 ACL、删除整个日历或清空主日历。
+
+## Audience 与验证
+
+- 公司 Google Workspace 组织内自用时，优先把 Audience 配为 `Internal`。
+- 个人 Gmail 或跨组织使用通常只能选择 `External`。Publishing status 为 Testing 且请求用户数据 scopes 时，refresh token 可能只有 7 天有效期。
+- 面向其他用户发布、在服务器存储或传输日历数据时，按 Google OAuth verification 和数据安全要求处理。
+- 事件标题、描述、参会人和会议链接进入 Agent 上下文意味着数据会离开 Google Calendar；操作公司日历前确认组织数据政策允许。
+
+## 常见问题
+
+### `access_denied` 或未验证应用提示
+
+确认当前账号属于允许的 Audience/Test users，并确认 consent screen 已声明三个 Calendar scopes。External 应用是否需要发布或验证取决于实际用户范围和数据处理方式。
+
+### 401 / 403 或 `insufficientPermissions`
+
+依次检查：
+
+1. Calendar API 是否已在 OAuth Client 所属 Project 启用。
+2. token 是否由 Google Calendar CLI 生成并包含三个必要 scope。
+3. Workspace API Controls 是否允许该 Client ID。
+4. 当前账号是否对目标日历和事件具有相应权限。
+
+scope 变化后执行：
+
+```bash
+./scripts/google_calendar_cli.py auth logout
+./scripts/google_calendar_cli.py auth login
+```
+
+### 本地 logout 与远端撤销
+
+`auth logout` 只删除本机 Calendar token，不会撤销 Google Account 中的应用授权。需要远端撤销时，应在 Google Account 安全设置或 Workspace Admin Console 中操作并确认影响范围；Google 的 OAuth 撤销可能使同一 Cloud Project 下已经授予的其他 scopes 和 token 一并失效。
+
+### 凭据安全
+
+- 不要把 `client_secret.json` 或 `token.json` 提交到仓库、Issue、PR 或聊天。
+- Desktop client secret 不是可依赖的强机密；用户授权后的 refresh token 才是关键敏感凭据。
+- token 与配置目录由 CLI 分别设为 `0600` 和 `0700`。
+- 设备丢失、离职或权限误授时，应尽快从 Google Account 或 Workspace Admin Console 撤销应用访问。

--- a/skills/google-calendar-cli/scripts/google_calendar_cli.py
+++ b/skills/google-calendar-cli/scripts/google_calendar_cli.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env -S uv run --script
+#
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "google-api-python-client>=2.200.0",
+#     "google-auth-httplib2>=0.4.2",
+#     "google-auth-oauthlib>=1.4.1",
+#     "rich>=15.0.0",
+#     "typer>=0.27.2",
+# ]
+# ///
+
+"""面向 Codex skill 的 Google Calendar API 命令行工具。"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import typer
+from google.auth.exceptions import GoogleAuthError
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from rich.console import Console
+from rich.pretty import Pretty
+
+APP_NAME = "google-calendar-cli"
+CLIENT_SECRET_ENV = "GOOGLE_WORKSPACE_CLIENT_SECRET"
+CLIENT_SECRET_FILENAME = "client_secret.json"
+TOKEN_FILENAME = "token.json"
+AUTH_DOC = "references/google-workspace-oauth.md"
+SCOPES = [
+    "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.events.freebusy",
+]
+
+app = typer.Typer(no_args_is_help=True)
+auth_app = typer.Typer(no_args_is_help=True, help="认证相关操作。")
+calendars_app = typer.Typer(no_args_is_help=True, help="查看已订阅的日历。")
+events_app = typer.Typer(no_args_is_help=True, help="读取和管理日历事件。")
+freebusy_app = typer.Typer(no_args_is_help=True, help="查询日历空闲/忙碌时间。")
+console = Console()
+
+
+class CliError(RuntimeError):
+    """面向用户展示的 CLI 错误。"""
+
+
+class SendUpdates(str, Enum):
+    """Google Calendar 参会人通知范围。"""
+
+    none = "none"
+    all = "all"
+    external_only = "externalOnly"
+
+
+class EventOrder(str, Enum):
+    """事件列表排序方式。"""
+
+    start_time = "startTime"
+    updated = "updated"
+
+
+def xdg_config_home() -> Path:
+    """返回 XDG 配置目录。"""
+    value = os.environ.get("XDG_CONFIG_HOME")
+    if value:
+        return Path(value).expanduser()
+    return Path.home() / ".config"
+
+
+def config_dir() -> Path:
+    """返回 Calendar token 的独立配置目录。"""
+    return xdg_config_home() / APP_NAME
+
+
+def client_secret_candidates() -> list[Path]:
+    """按优先级返回可复用的 Desktop OAuth client secret 路径。"""
+    candidates: list[Path] = []
+    configured = os.environ.get(CLIENT_SECRET_ENV)
+    if configured:
+        candidates.append(Path(configured).expanduser())
+    candidates.extend(
+        [
+            xdg_config_home() / "google-workspace-cli" / CLIENT_SECRET_FILENAME,
+            xdg_config_home() / "google-sheets-cli" / CLIENT_SECRET_FILENAME,
+        ]
+    )
+    return candidates
+
+
+def client_secret_path() -> Path:
+    """返回明确配置的或第一个存在的 client secret。"""
+    candidates = client_secret_candidates()
+    if os.environ.get(CLIENT_SECRET_ENV):
+        return candidates[0]
+    return next((path for path in candidates if path.exists()), candidates[0])
+
+
+def token_path() -> Path:
+    """返回 Calendar 专用 token 路径。"""
+    return config_dir() / TOKEN_FILENAME
+
+
+def credential_paths_payload() -> dict[str, Any]:
+    """返回不包含凭据内容的认证路径信息。"""
+    selected = client_secret_path()
+    return {
+        "config_dir": str(config_dir()),
+        "client_secret": str(selected),
+        "client_secret_source": (
+            "environment"
+            if os.environ.get(CLIENT_SECRET_ENV)
+            else "first_existing_candidate"
+        ),
+        "client_secret_candidates": [
+            {"path": str(path), "exists": path.exists()}
+            for path in client_secret_candidates()
+        ],
+        "token": str(token_path()),
+    }
+
+
+def missing_client_secret_message(path: Path) -> str:
+    """生成可执行的 client secret 缺失提示。"""
+    return f"""缺少 Google OAuth Desktop client secret：{path}
+
+可选处理方式：
+1. 把共享凭据保存到 ~/.config/google-workspace-cli/client_secret.json；或
+2. 直接复用 ~/.config/google-sheets-cli/client_secret.json；或
+3. 设置 {CLIENT_SECRET_ENV} 指向已有 JSON 文件。
+
+然后运行：./scripts/google_calendar_cli.py auth login
+详细配置见 {AUTH_DOC}。"""
+
+
+def missing_token_message(path: Path) -> str:
+    """生成可执行的 Calendar token 缺失提示。"""
+    return f"""缺少 Google Calendar OAuth token：{path}
+
+运行：./scripts/google_calendar_cli.py auth login
+Calendar token 与 Gmail、Sheets token 分开保存，不能直接复制复用。
+详细配置见 {AUTH_DOC}。"""
+
+
+def ensure_client_secret_exists() -> Path:
+    """确认 Desktop OAuth client secret 存在。"""
+    path = client_secret_path()
+    if not path.exists():
+        raise CliError(missing_client_secret_message(path))
+    return path
+
+
+def missing_scopes(credentials: Credentials) -> list[str]:
+    """返回 token 尚未授权的必要 scope。"""
+    return [scope for scope in SCOPES if not credentials.has_scopes([scope])]
+
+
+def write_token(credentials: Credentials) -> None:
+    """以仅当前用户可读写的方式原子保存 token。"""
+    directory = config_dir()
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    directory.chmod(0o700)
+    destination = token_path()
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=directory,
+            prefix=".token-",
+            suffix=".json",
+            delete=False,
+        ) as file:
+            temporary = Path(file.name)
+            file.write(credentials.to_json())
+        temporary.chmod(0o600)
+        temporary.replace(destination)
+        destination.chmod(0o600)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def load_credentials() -> Credentials:
+    """读取、校验并按需刷新 Calendar OAuth token。"""
+    ensure_client_secret_exists()
+    path = token_path()
+    if not path.exists():
+        raise CliError(missing_token_message(path))
+    try:
+        credentials = Credentials.from_authorized_user_file(str(path), SCOPES)
+    except (ValueError, GoogleAuthError) as exc:
+        raise CliError(
+            f"Calendar token 无法读取或格式不正确：{path}\n"
+            "请执行 auth logout 后重新执行 auth login。"
+        ) from exc
+    missing = missing_scopes(credentials)
+    if missing:
+        raise CliError(
+            "Calendar token 缺少必要 scope：\n- "
+            + "\n- ".join(missing)
+            + "\nDesktop app 不支持增量授权，请执行 auth logout 后重新登录。"
+        )
+    if credentials.valid:
+        return credentials
+    if credentials.expired and credentials.refresh_token:
+        try:
+            credentials.refresh(Request())
+        except GoogleAuthError as exc:
+            raise CliError(
+                "Calendar token 刷新失败，可能是授权被撤销、scope 变化或 "
+                "Workspace 策略阻止。请重新执行 auth login。"
+            ) from exc
+        write_token(credentials)
+        return credentials
+    raise CliError("Calendar token 无效且无法刷新，请重新执行 auth login。")
+
+
+def get_service() -> Any:
+    """构造 Google Calendar API v3 client。"""
+    return build(
+        "calendar", "v3", credentials=load_credentials(), cache_discovery=False
+    )
+
+
+def render_output(ctx: typer.Context, payload: Any) -> None:
+    """根据全局参数输出 JSON 或人类可读结构。"""
+    if ctx.obj and ctx.obj.get("json_output"):
+        console.print_json(data=payload)
+        return
+    console.print(Pretty(payload, expand_all=True))
+
+
+def execute(request: Any) -> Any:
+    """执行 Google API 请求并转换常见 HTTP 错误。"""
+    try:
+        return request.execute()
+    except HttpError as exc:
+        status = getattr(exc.resp, "status", "unknown")
+        reason = getattr(exc, "reason", None) or str(exc)
+        raise CliError(
+            f"Google Calendar API 请求失败（HTTP {status}）：{reason}"
+        ) from exc
+
+
+def load_json_arg(raw: str, option_name: str) -> Any:
+    """读取内联 JSON 或 @path 指向的 UTF-8 JSON 文件。"""
+    source = raw
+    if raw.startswith("@"):
+        path = Path(raw[1:]).expanduser()
+        if not path.exists():
+            raise CliError(f"{option_name} 指向的文件不存在：{path}")
+        source = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(source)
+    except json.JSONDecodeError as exc:
+        raise CliError(f"{option_name} 不是合法 JSON：{exc}") from exc
+
+
+def require_confirmation(value: bool, option: str, operation: str) -> None:
+    """要求调用方对写操作提供显式确认。"""
+    if not value:
+        raise CliError(f"{operation}会修改 Google Calendar；确认后添加 {option}。")
+
+
+def parse_rfc3339(value: str, option_name: str) -> datetime:
+    """解析带时区的 RFC3339 时间。"""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise CliError(f"{option_name} 必须是合法 RFC3339 时间：{value}") from exc
+    if parsed.utcoffset() is None:
+        raise CliError(f"{option_name} 必须包含时区偏移或 Z：{value}")
+    return parsed
+
+
+def ensure_time_window(time_min: str | None, time_max: str | None) -> None:
+    """校验可选 RFC3339 时间窗口。"""
+    start = parse_rfc3339(time_min, "--time-min") if time_min else None
+    end = parse_rfc3339(time_max, "--time-max") if time_max else None
+    if start is not None and end is not None and end <= start:
+        raise CliError("--time-max 必须晚于 --time-min。")
+
+
+def _event_endpoint(value: Any, field: str, option_name: str) -> tuple[str, Any]:
+    """校验事件 start/end 端点并返回类型和值。"""
+    if not isinstance(value, dict):
+        raise CliError(f"{option_name}.{field} 必须是对象。")
+    present = [name for name in ("date", "dateTime") if name in value]
+    if len(present) != 1 or not isinstance(value[present[0]], str):
+        raise CliError(f"{option_name}.{field} 必须且只能包含字符串 date 或 dateTime。")
+    kind = present[0]
+    raw = value[kind]
+    if kind == "date":
+        try:
+            return kind, date.fromisoformat(raw)
+        except ValueError as exc:
+            raise CliError(f"{option_name}.{field}.date 必须是 YYYY-MM-DD。") from exc
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise CliError(
+            f"{option_name}.{field}.dateTime 必须是合法 RFC3339 时间。"
+        ) from exc
+    if parsed.utcoffset() is not None:
+        return kind, parsed
+    time_zone = value.get("timeZone")
+    if not isinstance(time_zone, str) or not time_zone:
+        raise CliError(
+            f"{option_name}.{field}.dateTime 不带偏移时必须同时提供 timeZone。"
+        )
+    try:
+        return kind, parsed.replace(tzinfo=ZoneInfo(time_zone))
+    except ZoneInfoNotFoundError as exc:
+        raise CliError(
+            f"{option_name}.{field}.timeZone 不是已知 IANA 时区：{time_zone}"
+        ) from exc
+
+
+def validate_event_body(
+    value: Any, option_name: str, *, create: bool
+) -> dict[str, Any]:
+    """校验 create/patch 使用的事件 JSON 基本契约。"""
+    if not isinstance(value, dict) or not value:
+        raise CliError(f"{option_name} 必须是非空 JSON 对象。")
+    if not create:
+        return value
+    missing = [field for field in ("start", "end") if field not in value]
+    if missing:
+        raise CliError(f"{option_name} 创建事件时缺少字段：{', '.join(missing)}。")
+    start_kind, start = _event_endpoint(value["start"], "start", option_name)
+    end_kind, end = _event_endpoint(value["end"], "end", option_name)
+    if start_kind != end_kind:
+        raise CliError(f"{option_name}.start 和 end 必须同时使用 date 或 dateTime。")
+    if end <= start:
+        raise CliError(
+            f"{option_name}.end 必须晚于 start；全天事件的 end 日期不包含在内。"
+        )
+    return value
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(
+        False, "--json", help="输出 JSON，方便 Agent 解析。"
+    ),
+) -> None:
+    """初始化全局输出选项。"""
+    ctx.obj = {"json_output": json_output}
+
+
+@auth_app.command("paths", help="显示凭据候选路径，不读取凭据内容。")
+def auth_paths(ctx: typer.Context) -> None:
+    """显示认证路径。"""
+    payload = credential_paths_payload()
+    payload["client_secret_exists"] = client_secret_path().exists()
+    payload["token_exists"] = token_path().exists()
+    render_output(ctx, payload)
+
+
+@auth_app.command("doctor", help="检查 OAuth client、token 和 scopes。")
+def auth_doctor(ctx: typer.Context) -> None:
+    """检查认证状态。"""
+    payload = credential_paths_payload()
+    if not client_secret_path().exists():
+        payload.update(
+            status="missing_client_secret",
+            next_step=missing_client_secret_message(client_secret_path()),
+        )
+        render_output(ctx, payload)
+        return
+    if not token_path().exists():
+        payload.update(
+            status="missing_token", next_step=missing_token_message(token_path())
+        )
+        render_output(ctx, payload)
+        return
+    credentials = load_credentials()
+    payload.update(
+        status="ok" if credentials.valid else "invalid",
+        scopes=list(credentials.scopes or SCOPES),
+        expiry=credentials.expiry.isoformat() if credentials.expiry else None,
+    )
+    render_output(ctx, payload)
+
+
+@auth_app.command("login", help="执行 Desktop OAuth 登录并保存 Calendar token。")
+def auth_login(
+    ctx: typer.Context,
+    open_browser: bool = typer.Option(
+        True, "--open-browser/--no-open-browser", help="是否自动打开系统浏览器。"
+    ),
+) -> None:
+    """执行完整 Calendar scopes 授权。"""
+    secret = ensure_client_secret_exists()
+    flow = InstalledAppFlow.from_client_secrets_file(str(secret), SCOPES)
+    credentials = flow.run_local_server(
+        port=0, open_browser=open_browser, access_type="offline", prompt="consent"
+    )
+    missing = missing_scopes(credentials)
+    if missing:
+        raise CliError("用户未授予必要 scope：" + ", ".join(missing))
+    write_token(credentials)
+    render_output(
+        ctx,
+        {
+            "status": "ok",
+            "token": str(token_path()),
+            "scopes": list(credentials.scopes or SCOPES),
+        },
+    )
+
+
+@auth_app.command("logout", help="删除本机 Calendar token，不删除共享 client secret。")
+def auth_logout(ctx: typer.Context) -> None:
+    """删除 Calendar token。"""
+    path = token_path()
+    existed = path.exists()
+    if existed:
+        path.unlink()
+    render_output(ctx, {"status": "ok", "removed": existed, "token": str(path)})
+
+
+@calendars_app.command("list", help="列出当前账号订阅的日历。")
+def calendars_list(
+    ctx: typer.Context,
+    max_results: int = typer.Option(100, "--max-results", min=1, max=250),
+    page_token: str | None = typer.Option(None, "--page-token"),
+    show_hidden: bool = typer.Option(False, "--show-hidden"),
+    show_deleted: bool = typer.Option(False, "--show-deleted"),
+) -> None:
+    """列出 CalendarList 中的日历。"""
+    kwargs: dict[str, Any] = {
+        "maxResults": max_results,
+        "showHidden": show_hidden,
+        "showDeleted": show_deleted,
+    }
+    if page_token:
+        kwargs["pageToken"] = page_token
+    render_output(ctx, execute(get_service().calendarList().list(**kwargs)))
+
+
+@calendars_app.command("get", help="读取一个已订阅日历的元数据。")
+def calendars_get(
+    ctx: typer.Context,
+    calendar_id: str = typer.Option("primary", "--calendar-id"),
+) -> None:
+    """读取 CalendarList entry。"""
+    result = execute(get_service().calendarList().get(calendarId=calendar_id))
+    render_output(ctx, result)
+
+
+@events_app.command("list", help="按时间窗口或关键词列出事件。")
+def events_list(
+    ctx: typer.Context,
+    calendar_id: str = typer.Option("primary", "--calendar-id"),
+    time_min: str | None = typer.Option(None, "--time-min"),
+    time_max: str | None = typer.Option(None, "--time-max"),
+    query: str | None = typer.Option(None, "--query", "-q"),
+    max_results: int = typer.Option(50, "--max-results", min=1, max=2500),
+    page_token: str | None = typer.Option(None, "--page-token"),
+    single_events: bool = typer.Option(
+        True, "--single-events/--series", help="展开实例或返回重复事件系列。"
+    ),
+    order_by: EventOrder | None = typer.Option(EventOrder.start_time, "--order-by"),
+    show_deleted: bool = typer.Option(False, "--show-deleted"),
+) -> None:
+    """列出单个日历的事件。"""
+    ensure_time_window(time_min, time_max)
+    if order_by is EventOrder.start_time and not single_events:
+        raise CliError("--order-by startTime 只能和 --single-events 一起使用。")
+    kwargs: dict[str, Any] = {
+        "calendarId": calendar_id,
+        "maxResults": max_results,
+        "singleEvents": single_events,
+        "showDeleted": show_deleted,
+    }
+    for key, value in (
+        ("timeMin", time_min),
+        ("timeMax", time_max),
+        ("q", query),
+        ("pageToken", page_token),
+        ("orderBy", order_by.value if order_by else None),
+    ):
+        if value is not None:
+            kwargs[key] = value
+    render_output(ctx, execute(get_service().events().list(**kwargs)))
+
+
+@events_app.command("get", help="按 event ID 读取事件。")
+def events_get(
+    ctx: typer.Context,
+    event_id: str = typer.Option(..., "--event-id"),
+    calendar_id: str = typer.Option("primary", "--calendar-id"),
+) -> None:
+    """读取一个事件。"""
+    result = execute(
+        get_service().events().get(calendarId=calendar_id, eventId=event_id)
+    )
+    render_output(ctx, result)
+
+
+@events_app.command("instances", help="列出重复事件系列的实例。")
+def events_instances(
+    ctx: typer.Context,
+    event_id: str = typer.Option(..., "--event-id"),
+    calendar_id: str = typer.Option("primary", "--calendar-id"),
+    time_min: str | None = typer.Option(None, "--time-min"),
+    time_max: str | None = typer.Option(None, "--time-max"),
+    max_results: int = typer.Option(50, "--max-results", min=1, max=2500),
+    page_token: str | None = typer.Option(None, "--page-token"),
+    show_deleted: bool = typer.Option(False, "--show-deleted"),
+) -> None:
+    """列出重复事件的具体实例。"""
+    ensure_time_window(time_min, time_max)
+    kwargs: dict[str, Any] = {
+        "calendarId": calendar_id,
+        "eventId": event_id,
+        "maxResults": max_results,
+        "showDeleted": show_deleted,
+    }
+    for key, value in (
+        ("timeMin", time_min),
+        ("timeMax", time_max),
+        ("pageToken", page_token),
+    ):
+        if value is not None:
+            kwargs[key] = value
+    render_output(ctx, execute(get_service().events().instances(**kwargs)))
+
+
+@events_app.command("create", help="从 Google Event JSON 创建事件。")
+def events_create(
+    ctx: typer.Context,
+    event_json: str = typer.Option(..., "--event-json"),
+    calendar_id: str = typer.Option("primary", "--calendar-id"),
+    send_updates: SendUpdates = typer.Option(SendUpdates.none, "--send-updates"),
+    conference_data_version: int = typer.Option(
+        0, "--conference-data-version", min=0, max=1
+    ),
+    confirm_create: bool = typer.Option(False, "--confirm-create"),
+) -> None:
+    """创建事件，并显式控制参会人通知。"""
+    require_confirmation(confirm_create, "--confirm-create", "创建事件")
+    body = validate_event_body(
+        load_json_arg(event_json, "--event-json"), "--event-json", create=True
+    )
+    result = execute(
+        get_service()
+        .events()
+        .insert(
+            calendarId=calendar_id,
+            body=body,
+            sendUpdates=send_updates.value,
+            conferenceDataVersion=conference_data_version,
+        )
+    )
+    render_output(ctx, result)
+
+
+@events_app.command("patch", help="从 Google Event JSON 局部更新事件。")
+def events_patch(
+    ctx: typer.Context,
+    event_id: str = typer.Option(..., "--event-id"),
+    event_json: str = typer.Option(..., "--event-json"),
+    calendar_id: str = typer.Option("primary", "--calendar-id"),
+    send_updates: SendUpdates = typer.Option(SendUpdates.none, "--send-updates"),
+    conference_data_version: int = typer.Option(
+        0, "--conference-data-version", min=0, max=1
+    ),
+    confirm_update: bool = typer.Option(False, "--confirm-update"),
+) -> None:
+    """局部更新事件，并显式控制参会人通知。"""
+    require_confirmation(confirm_update, "--confirm-update", "更新事件")
+    body = validate_event_body(
+        load_json_arg(event_json, "--event-json"), "--event-json", create=False
+    )
+    result = execute(
+        get_service()
+        .events()
+        .patch(
+            calendarId=calendar_id,
+            eventId=event_id,
+            body=body,
+            sendUpdates=send_updates.value,
+            conferenceDataVersion=conference_data_version,
+        )
+    )
+    render_output(ctx, result)
+
+
+@events_app.command("delete", help="删除事件或重复事件实例。")
+def events_delete(
+    ctx: typer.Context,
+    event_id: str = typer.Option(..., "--event-id"),
+    calendar_id: str = typer.Option("primary", "--calendar-id"),
+    send_updates: SendUpdates = typer.Option(SendUpdates.none, "--send-updates"),
+    confirm_delete: bool = typer.Option(False, "--confirm-delete"),
+) -> None:
+    """删除事件，并显式控制参会人通知。"""
+    require_confirmation(confirm_delete, "--confirm-delete", "删除事件")
+    execute(
+        get_service()
+        .events()
+        .delete(
+            calendarId=calendar_id,
+            eventId=event_id,
+            sendUpdates=send_updates.value,
+        )
+    )
+    render_output(
+        ctx,
+        {
+            "status": "ok",
+            "calendarId": calendar_id,
+            "deleted": event_id,
+            "sendUpdates": send_updates.value,
+        },
+    )
+
+
+@freebusy_app.command("query", help="查询一个或多个日历的忙碌时间段。")
+def freebusy_query(
+    ctx: typer.Context,
+    calendar_ids: list[str] = typer.Option(..., "--calendar-id"),
+    time_min: str = typer.Option(..., "--time-min"),
+    time_max: str = typer.Option(..., "--time-max"),
+    time_zone: str | None = typer.Option(None, "--time-zone"),
+    group_expansion_max: int = typer.Option(
+        100, "--group-expansion-max", min=1, max=100
+    ),
+    calendar_expansion_max: int = typer.Option(
+        50, "--calendar-expansion-max", min=1, max=50
+    ),
+) -> None:
+    """查询 RFC3339 时间窗口中的 busy 区间。"""
+    ensure_time_window(time_min, time_max)
+    if not calendar_ids or any(not item.strip() for item in calendar_ids):
+        raise CliError("至少需要一个非空 --calendar-id。")
+    body: dict[str, Any] = {
+        "timeMin": time_min,
+        "timeMax": time_max,
+        "items": [{"id": item} for item in calendar_ids],
+        "groupExpansionMax": group_expansion_max,
+        "calendarExpansionMax": calendar_expansion_max,
+    }
+    if time_zone:
+        body["timeZone"] = time_zone
+    render_output(ctx, execute(get_service().freebusy().query(body=body)))
+
+
+app.add_typer(auth_app, name="auth")
+app.add_typer(calendars_app, name="calendars")
+app.add_typer(events_app, name="events")
+app.add_typer(freebusy_app, name="freebusy")
+
+
+def run() -> None:
+    """运行 CLI 并以简洁方式展示预期错误。"""
+    try:
+        app()
+    except CliError as exc:
+        console.print(f"[red]错误：[/red]{exc}", markup=True)
+        raise SystemExit(1) from None
+
+
+if __name__ == "__main__":
+    run()

--- a/skills/google-calendar-cli/scripts/tests/test_google_calendar_cli.py
+++ b/skills/google-calendar-cli/scripts/tests/test_google_calendar_cli.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "google_calendar_cli.py"
+
+
+def load_cli_module():
+    spec = importlib.util.spec_from_file_location("google_calendar_cli", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_client_secret_reuses_shared_secret_and_keeps_token_separate(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("GOOGLE_WORKSPACE_CLIENT_SECRET", raising=False)
+    shared_secret = tmp_path / "google-workspace-cli" / "client_secret.json"
+    shared_secret.parent.mkdir()
+    shared_secret.write_text("{}", encoding="utf-8")
+    cli = load_cli_module()
+
+    assert cli.client_secret_path() == shared_secret
+    assert cli.token_path() == tmp_path / "google-calendar-cli" / "token.json"
+
+
+def test_client_secret_falls_back_to_existing_sheets_secret(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("GOOGLE_WORKSPACE_CLIENT_SECRET", raising=False)
+    sheets_secret = tmp_path / "google-sheets-cli" / "client_secret.json"
+    sheets_secret.parent.mkdir()
+    sheets_secret.write_text("{}", encoding="utf-8")
+    cli = load_cli_module()
+
+    assert cli.client_secret_path() == sheets_secret
+
+
+def test_explicit_client_secret_path_has_priority(monkeypatch, tmp_path):
+    configured = tmp_path / "oauth" / "desktop.json"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("GOOGLE_WORKSPACE_CLIENT_SECRET", str(configured))
+    cli = load_cli_module()
+
+    assert cli.client_secret_path() == configured
+
+
+def test_write_token_uses_private_permissions_and_atomic_replacement(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    cli = load_cli_module()
+
+    class Credentials:
+        def to_json(self):
+            return json.dumps({"refresh_token": "test-only"})
+
+    cli.write_token(Credentials())
+
+    assert cli.config_dir().stat().st_mode & 0o777 == 0o700
+    assert cli.token_path().stat().st_mode & 0o777 == 0o600
+    assert json.loads(cli.token_path().read_text(encoding="utf-8")) == {
+        "refresh_token": "test-only"
+    }
+    assert list(cli.config_dir().glob(".token-*.json")) == []
+
+
+def test_required_scopes_are_narrow_and_do_not_include_full_calendar_scope():
+    cli = load_cli_module()
+
+    assert "https://www.googleapis.com/auth/calendar" not in cli.SCOPES
+    assert cli.SCOPES == [
+        "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.events.freebusy",
+    ]
+
+
+@pytest.mark.parametrize(
+    "time_min,time_max,message",
+    [
+        ("2026-09-04T10:00:00", None, "时区"),
+        ("not-a-time", None, "RFC3339"),
+        (
+            "2026-09-04T11:00:00+08:00",
+            "2026-09-04T10:00:00+08:00",
+            "晚于",
+        ),
+    ],
+)
+def test_time_window_rejects_invalid_or_reversed_values(time_min, time_max, message):
+    cli = load_cli_module()
+
+    with pytest.raises(cli.CliError, match=message):
+        cli.ensure_time_window(time_min, time_max)
+
+
+def test_event_create_body_accepts_timed_and_all_day_events():
+    cli = load_cli_module()
+    timed = {
+        "summary": "sync",
+        "start": {"dateTime": "2026-09-04T10:00:00+08:00"},
+        "end": {"dateTime": "2026-09-04T10:30:00+08:00"},
+    }
+    all_day = {
+        "summary": "holiday",
+        "start": {"date": "2026-09-04"},
+        "end": {"date": "2026-09-05"},
+    }
+    named_time_zone = {
+        "summary": "weekly sync",
+        "start": {
+            "dateTime": "2026-09-04T10:00:00",
+            "timeZone": "Asia/Shanghai",
+        },
+        "end": {
+            "dateTime": "2026-09-04T10:30:00",
+            "timeZone": "Asia/Shanghai",
+        },
+    }
+
+    assert cli.validate_event_body(timed, "--event-json", create=True) == timed
+    assert cli.validate_event_body(all_day, "--event-json", create=True) == all_day
+    assert (
+        cli.validate_event_body(named_time_zone, "--event-json", create=True)
+        == named_time_zone
+    )
+
+
+@pytest.mark.parametrize(
+    "value,message",
+    [
+        ({"summary": "missing times"}, "缺少字段"),
+        (
+            {
+                "start": {"date": "2026-09-04"},
+                "end": {"dateTime": "2026-09-05T00:00:00+08:00"},
+            },
+            "同时使用",
+        ),
+        (
+            {
+                "start": {"dateTime": "2026-09-04T11:00:00+08:00"},
+                "end": {"dateTime": "2026-09-04T10:00:00+08:00"},
+            },
+            "晚于",
+        ),
+    ],
+)
+def test_event_create_body_rejects_invalid_contract(value, message):
+    cli = load_cli_module()
+
+    with pytest.raises(cli.CliError, match=message):
+        cli.validate_event_body(value, "--event-json", create=True)
+
+
+def test_write_operations_require_explicit_confirmation():
+    cli = load_cli_module()
+
+    with pytest.raises(cli.CliError, match="--confirm-delete"):
+        cli.require_confirmation(False, "--confirm-delete", "删除事件")
+
+    cli.require_confirmation(True, "--confirm-delete", "删除事件")
+
+
+def test_event_create_passes_notification_and_conference_controls(monkeypatch):
+    cli = load_cli_module()
+    captured = {}
+
+    class ApiRequest:
+        def execute(self):
+            return {"id": "event-1"}
+
+    class Events:
+        def insert(self, **kwargs):
+            captured.update(kwargs)
+            return ApiRequest()
+
+    class Service:
+        def events(self):
+            return Events()
+
+    monkeypatch.setattr(cli, "get_service", Service)
+    monkeypatch.setattr(
+        cli, "render_output", lambda _ctx, value: captured.update(output=value)
+    )
+    body = {
+        "summary": "sync",
+        "start": {"dateTime": "2026-09-04T10:00:00+08:00"},
+        "end": {"dateTime": "2026-09-04T10:30:00+08:00"},
+    }
+
+    cli.events_create(
+        None,
+        event_json=json.dumps(body),
+        calendar_id="primary",
+        send_updates=cli.SendUpdates.all,
+        conference_data_version=1,
+        confirm_create=True,
+    )
+
+    assert captured["calendarId"] == "primary"
+    assert captured["body"] == body
+    assert captured["sendUpdates"] == "all"
+    assert captured["conferenceDataVersion"] == 1
+    assert captured["output"] == {"id": "event-1"}
+
+
+def test_events_list_defaults_to_expanded_start_order(monkeypatch):
+    cli = load_cli_module()
+    captured = {}
+
+    class ApiRequest:
+        def execute(self):
+            return {"items": []}
+
+    class Events:
+        def list(self, **kwargs):
+            captured.update(kwargs)
+            return ApiRequest()
+
+    class Service:
+        def events(self):
+            return Events()
+
+    monkeypatch.setattr(cli, "get_service", Service)
+    monkeypatch.setattr(cli, "render_output", lambda _ctx, _value: None)
+
+    cli.events_list(
+        None,
+        calendar_id="primary",
+        time_min="2026-09-04T00:00:00+08:00",
+        time_max="2026-09-05T00:00:00+08:00",
+        query=None,
+        max_results=50,
+        page_token=None,
+        single_events=True,
+        order_by=cli.EventOrder.start_time,
+        show_deleted=False,
+    )
+
+    assert captured == {
+        "calendarId": "primary",
+        "maxResults": 50,
+        "singleEvents": True,
+        "showDeleted": False,
+        "timeMin": "2026-09-04T00:00:00+08:00",
+        "timeMax": "2026-09-05T00:00:00+08:00",
+        "orderBy": "startTime",
+    }
+
+
+def test_freebusy_query_builds_multi_calendar_body(monkeypatch):
+    cli = load_cli_module()
+    captured = {}
+
+    class ApiRequest:
+        def execute(self):
+            return {"calendars": {}}
+
+    class Freebusy:
+        def query(self, **kwargs):
+            captured.update(kwargs)
+            return ApiRequest()
+
+    class Service:
+        def freebusy(self):
+            return Freebusy()
+
+    monkeypatch.setattr(cli, "get_service", Service)
+    monkeypatch.setattr(cli, "render_output", lambda _ctx, _value: None)
+
+    cli.freebusy_query(
+        None,
+        calendar_ids=["one@example.com", "two@example.com"],
+        time_min="2026-09-04T09:00:00+08:00",
+        time_max="2026-09-04T18:00:00+08:00",
+        time_zone="Asia/Shanghai",
+        group_expansion_max=100,
+        calendar_expansion_max=50,
+    )
+
+    assert captured["body"]["items"] == [
+        {"id": "one@example.com"},
+        {"id": "two@example.com"},
+    ]
+    assert captured["body"]["timeZone"] == "Asia/Shanghai"


### PR DESCRIPTION
## Why

- 仓库已有 Google Mail 与 Google Sheets CLI，但缺少可复用且有明确写入边界的 Google Calendar 交互能力。
- 日历事件包含参会人通知、重复事件实例和 free/busy 等特殊语义，需要统一认证、校验与确认流程。

## What

- 新增基于 PEP 723 的 `google-calendar-cli`，支持认证检查、日历与事件读取、重复事件实例、事件创建/局部更新/删除，以及 free/busy 查询。
- 复用共享 Desktop OAuth Client secret，同时将 Calendar token 独立保存并原子写入；仅申请日历列表只读、事件管理和 free/busy 三个范围，并为写操作增加显式确认与通知范围控制。
- 新增 skill 使用说明、OAuth 配置指南、行为测试及 README 索引。

## Validation

- 使用现有 Desktop OAuth Client 完成独立授权，并在真实账号上验证 `calendarList`、`events` 和 `freeBusy` 三个只读接口；凭据和日程数据均只保留在本机配置目录，未写入仓库。
- 最终 PR diff 的凭据扫描只命中环境变量名与文件名常量，未发现 Client secret、token、真实邮箱、Cloud Project ID、event ID、本机绝对路径或日程内容。
