### PR TITLE
feat(github-cli): 增加统一 Actions 等待工具

### DIFF
--- a/plugins/dcjanus/skills/codex-session-reader/scripts/codex_session_reader.py
+++ b/plugins/dcjanus/skills/codex-session-reader/scripts/codex_session_reader.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "openai-codex>=0.147.0",
+#     "openai-codex>=0.154.0",
 #     "pydantic>=2.13.5",
 #     "rich>=15.0.0",
 #     "typer>=0.27.2",

--- a/plugins/dcjanus/skills/codex-thread-namer/scripts/set_current_thread_name.py
+++ b/plugins/dcjanus/skills/codex-thread-namer/scripts/set_current_thread_name.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "openai-codex>=0.147.0",
+#     "openai-codex>=0.154.0",
 # ]
 # [tool.uv]
 # prerelease = "allow"

--- a/plugins/dcjanus/skills/github-cli/SKILL.md
+++ b/plugins/dcjanus/skills/github-cli/SKILL.md
@@ -22,6 +22,7 @@ description: 使用 GitHub CLI 与 GitHub 资源交互；适用于 repo、issue�
 - 仓库、Issue、PR、评论、release、workflow 等资源，优先先用 `gh <group> --help` 确认是否有现成子命令，再执行。
 - 需要机器可读输出时，优先使用 `--json`，必要时再配合 `jq` 整理字段。
 - 用户明确要求采用 DCjanus 的个人合并策略时，使用 [dcjanus-merge-policy](../dcjanus-merge-policy/SKILL.md)。
+- 当 Agent 需要持续等待 workflow run、单个 job 或 PR checks 时，不要手写 shell 轮询或反复调用 `gh api`；先完整读取 [actions-wait.md](references/actions-wait.md)，再使用统一脚本。人工临时查看仍可直接使用 `gh run watch`。
 
 ## PR Review
 

--- a/plugins/dcjanus/skills/github-cli/references/actions-wait.md
+++ b/plugins/dcjanus/skills/github-cli/references/actions-wait.md
@@ -1,0 +1,84 @@
+# GitHub Actions 等待
+
+当 Agent 需要阻塞等待 GitHub Actions，并希望获得低噪声输出、统一超时或稳定退出码时，使用 `scripts/github_actions_wait.py`。脚本只读取 GitHub 状态，不会取消、重跑 workflow，也不会修改 PR 或 check。
+
+## 选择原则
+
+- 人工临时观察完整 step 进度：使用 `gh run watch`；需要失败退出时加 `--exit-status`。
+- 人工观察 PR checks：可使用 `gh pr checks --watch --fail-fast`。
+- Agent 阻塞等待、单 job、按名称筛选、超时控制、NDJSON 或只在状态变化时输出：使用本脚本。
+
+脚本轮询 REST API，不是真正的 webhook 事件流。两次轮询之间出现又消失的状态可能不可见，事件时间表示脚本观察到状态的时间，而不是 GitHub 服务端状态产生的时间。
+
+## 命令接口
+
+从本 skill 目录运行：
+
+```bash
+./scripts/github_actions_wait.py --repo owner/repo --run 123
+./scripts/github_actions_wait.py --repo owner/repo --job 456
+./scripts/github_actions_wait.py --repo owner/repo --pr 789
+./scripts/github_actions_wait.py --repo owner/repo --pr 789 --fail-fast
+./scripts/github_actions_wait.py --repo owner/repo --pr 789 --check 'test-*'
+./scripts/github_actions_wait.py --repo owner/repo --run 123 --job-name 'test-*'
+./scripts/github_actions_wait.py --repo owner/repo --run 123 --interval 60 --timeout 30m --format ndjson
+```
+
+目标参数 `--run`、`--job` 和 `--pr` 三选一。`--job-name` 只能和 `--run` 一起使用，用于等待该 run 中匹配的 jobs；`--check` 只能和 `--pr` 一起使用。筛选参数可重复，采用区分大小写的 shell glob（例如 `test-*`）；任一 pattern 命中即保留。没有匹配项时保持 pending，直到匹配项出现或超时。
+
+`--fail-fast` 只用于 PR：任一匹配 check 失败或取消时立即退出，不等待其它 check。默认轮询间隔为 30 秒，默认超时为 30 分钟；时长接受秒数或 `s`、`m`、`h` 后缀。
+
+## 状态模型
+
+脚本把 GitHub 的 run、job、check run 和 commit status 归一成四种状态：
+
+| 状态 | 含义 |
+| --- | --- |
+| `pending` | 尚未出现匹配项，或至少一项 queued/in progress |
+| `success` | 全部匹配项成功；`neutral` 和 `skipped` 也视为成功完成 |
+| `failure` | 至少一项为 failure、timed out、action required、startup failure 或 stale |
+| `cancelled` | 至少一项取消，且没有失败项 |
+
+PR 模式同时读取 head SHA 的 check runs 和 commit statuses。未知的新状态不会被误报为成功，而会保持 pending 直至超时。
+
+## 输出契约
+
+默认 `human` 输出每行一个观察事件，不使用动态终端界面。`ndjson` 每行一个 JSON object，稳定字段为：
+
+- `event`：`state`、`retry`、`timeout`、`interrupted` 或 `error`；
+- `time`：UTC ISO 8601 观察时间；
+- `target`：`run`、`job` 或 `pr`；
+- `id`：目标 ID 或 PR number；
+- `state`：状态事件的归一化状态；
+- `status`、`conclusion`、`name`、`url`、`items`、`sha`：目标适用时出现的详情。
+
+第一次读取会输出 `state`；之后只有完整状态快照变化时才再次输出。连续相同的临时 API 错误只输出一次 `retry`。HTTP 429 或临时服务错误会遵循数值形式的 `Retry-After`，否则按 `--interval` 重试。
+
+## 退出码
+
+| 退出码 | 结果 |
+| --- | --- |
+| `0` | 成功 |
+| `1` | 失败 |
+| `2` | 命令行参数错误 |
+| `3` | 取消 |
+| `4` | 超时 |
+| `5` | 收到 Ctrl-C 或中断信号 |
+| `6` | 鉴权、配置或不可重试的 API 错误 |
+
+## 认证、host 与条件请求
+
+仓库接受 `OWNER/REPO`、`HOST/OWNER/REPO` 或完整 repository URL。未显式给出 host 时遵循 `GH_HOST`，否则默认 `github.com`。GitHub.com 使用 `https://api.github.com`；GitHub Enterprise Server 使用 `https://HOST/api/v3`。
+
+认证顺序与 `gh` 一致：GitHub.com 优先 `GH_TOKEN`、`GITHUB_TOKEN`；Enterprise 优先 `GH_ENTERPRISE_TOKEN`、`GITHUB_ENTERPRISE_TOKEN`，再回退通用 token。环境变量没有 token 时执行 `gh auth token --hostname HOST`，因此自然遵循 `GH_CONFIG_DIR`。错误与 NDJSON 不包含响应正文或 token。
+
+每个成功 GET 的响应若包含 ETag，后续请求会发送 `If-None-Match`；收到 304 时复用缓存。端点不返回 ETag 时会安全退回普通轮询。
+
+官方接口依据：
+
+- [Get a workflow run](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)
+- [Get a job for a workflow run](https://docs.github.com/en/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run)
+- [List check runs for a Git reference](https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference)
+- [Get the combined status for a specific reference](https://docs.github.com/en/rest/commits/statuses#get-the-combined-status-for-a-specific-reference)
+- [REST API conditional requests](https://docs.github.com/en/rest/guides/best-practices-for-using-the-rest-api#use-conditional-requests-if-appropriate)
+- [GitHub Enterprise Server API version](https://docs.github.com/en/enterprise-server/rest/about-the-rest-api/api-versions)

--- a/plugins/dcjanus/skills/github-cli/references/actions-wait.md
+++ b/plugins/dcjanus/skills/github-cli/references/actions-wait.md
@@ -70,7 +70,7 @@ PR 模式同时读取 head SHA 的 check runs 和 commit statuses。未知的新
 
 仓库接受 `OWNER/REPO`、`HOST/OWNER/REPO` 或完整 repository URL。未显式给出 host 时遵循 `GH_HOST`，否则默认 `github.com`。GitHub.com 使用 `https://api.github.com`；GitHub Enterprise Server 使用 `https://HOST/api/v3`。
 
-认证顺序与 `gh` 一致：GitHub.com 优先 `GH_TOKEN`、`GITHUB_TOKEN`；Enterprise 优先 `GH_ENTERPRISE_TOKEN`、`GITHUB_ENTERPRISE_TOKEN`，再回退通用 token。环境变量没有 token 时执行 `gh auth token --hostname HOST`，因此自然遵循 `GH_CONFIG_DIR`。错误与 NDJSON 不包含响应正文或 token。
+脚本只直接读取一个认证环境变量 `GH_TOKEN`，适用于 GitHub.com 和 Enterprise host；没有时执行 `gh auth token --hostname HOST`，因此自然遵循 `GH_CONFIG_DIR` 和该 host 当前选择的账号。GitHub Actions 中需要显式映射，例如 `GH_TOKEN: ${{ github.token }}`。脚本不直接读取名称更宽泛的 `GITHUB_TOKEN` 或 Enterprise 专用变量，避免同一环境中多个账号来源不明确。错误与 NDJSON 不包含响应正文或 token。
 
 每个成功 GET 的响应若包含 ETag，后续请求会发送 `If-None-Match`；收到 304 时复用缓存。端点不返回 ETag 时会安全退回普通轮询。
 

--- a/plugins/dcjanus/skills/github-cli/references/actions-wait.md
+++ b/plugins/dcjanus/skills/github-cli/references/actions-wait.md
@@ -70,7 +70,7 @@ PR 模式同时读取 head SHA 的 check runs 和 commit statuses。未知的新
 
 仓库接受 `OWNER/REPO`、`HOST/OWNER/REPO` 或完整 repository URL。未显式给出 host 时遵循 `GH_HOST`，否则默认 `github.com`。GitHub.com 使用 `https://api.github.com`；GitHub Enterprise Server 使用 `https://HOST/api/v3`。
 
-脚本只直接读取一个认证环境变量 `GH_TOKEN`，适用于 GitHub.com 和 Enterprise host；没有时执行 `gh auth token --hostname HOST`，因此自然遵循 `GH_CONFIG_DIR` 和该 host 当前选择的账号。GitHub Actions 中需要显式映射，例如 `GH_TOKEN: ${{ github.token }}`。脚本不直接读取名称更宽泛的 `GITHUB_TOKEN` 或 Enterprise 专用变量，避免同一环境中多个账号来源不明确。错误与 NDJSON 不包含响应正文或 token。
+认证环境变量遵循 GitHub CLI 在 GitHub.com 上的优先级：先读取 `GH_TOKEN`，再读取 `GITHUB_TOKEN`；均未设置时执行 `gh auth token --hostname HOST`，因此自然遵循 `GH_CONFIG_DIR` 和该 host 当前选择的账号。GitHub Actions 中可显式映射 `GH_TOKEN: ${{ github.token }}`。错误与 NDJSON 不包含响应正文或 token。
 
 每个成功 GET 的响应若包含 ETag，后续请求会发送 `If-None-Match`；收到 304 时复用缓存。端点不返回 ETag 时会安全退回普通轮询。
 

--- a/plugins/dcjanus/skills/github-cli/scripts/github_actions_wait.py
+++ b/plugins/dcjanus/skills/github-cli/scripts/github_actions_wait.py
@@ -222,8 +222,9 @@ def parse_repo(value: str, hostname: str | None = None) -> RepoRef:
 
 
 def resolve_token(hostname: str) -> str:
-    if token := os.environ.get("GH_TOKEN", "").strip():
-        return token
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        if token := os.environ.get(name, "").strip():
+            return token
     try:
         result = subprocess.run(
             ["gh", "auth", "token", "--hostname", hostname],

--- a/plugins/dcjanus/skills/github-cli/scripts/github_actions_wait.py
+++ b/plugins/dcjanus/skills/github-cli/scripts/github_actions_wait.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+
+"""Low-noise, read-only waiting for GitHub Actions runs, jobs, and PR checks."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, TextIO
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+API_VERSION = "2022-11-28"
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+EXIT_USAGE = 2
+EXIT_CANCELLED = 3
+EXIT_TIMEOUT = 4
+EXIT_INTERRUPTED = 5
+EXIT_API_ERROR = 6
+TRANSIENT_STATUS = {408, 429, 500, 502, 503, 504}
+SUCCESS_CONCLUSIONS = {"success", "neutral", "skipped"}
+FAILURE_CONCLUSIONS = {
+    "error",
+    "failure",
+    "timed_out",
+    "action_required",
+    "startup_failure",
+    "stale",
+}
+CANCELLED_CONCLUSIONS = {"cancelled"}
+
+
+class WaitError(RuntimeError):
+    """Base class for stable, user-facing failures."""
+
+
+class ApiError(WaitError):
+    """A non-retryable GitHub API failure."""
+
+
+class RetryableApiError(ApiError):
+    """A temporary GitHub API failure that may be retried."""
+
+    def __init__(self, message: str, *, retry_after: float | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class SignalInterrupt(KeyboardInterrupt):
+    """Raised when a termination signal requests a clean stop."""
+
+
+@dataclass(frozen=True)
+class RepoRef:
+    owner: str
+    name: str
+    hostname: str
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+
+@dataclass(frozen=True)
+class Target:
+    kind: str
+    identifier: int
+    names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RawResponse:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+
+class UrlTransport:
+    """Minimal injectable HTTP transport."""
+
+    def request(self, url: str, headers: dict[str, str]) -> RawResponse:
+        request = Request(url, headers=headers, method="GET")
+        try:
+            with urlopen(request, timeout=30) as response:
+                return RawResponse(
+                    response.status, dict(response.headers.items()), response.read()
+                )
+        except HTTPError as error:
+            return RawResponse(error.code, dict(error.headers.items()), error.read())
+        except (URLError, TimeoutError, OSError) as error:
+            raise RetryableApiError("temporary network error") from error
+
+
+class FakeableTransport:
+    """Deterministic transport used by tests and embedders."""
+
+    def __init__(self, responses: Iterable[RawResponse]) -> None:
+        self.responses = iter(responses)
+        self.requests: list[tuple[str, dict[str, str]]] = []
+
+    def request(self, url: str, headers: dict[str, str]) -> RawResponse:
+        self.requests.append((url, dict(headers)))
+        return next(self.responses)
+
+
+class GitHubApi:
+    """Read-only REST client with per-URL conditional request caching."""
+
+    def __init__(
+        self,
+        repo: RepoRef,
+        token: str,
+        *,
+        transport: Any | None = None,
+    ) -> None:
+        self.repo = repo
+        self.token = token
+        self.transport = transport or UrlTransport()
+        self.rest_base = (
+            "https://api.github.com"
+            if repo.hostname == "github.com"
+            else f"https://{repo.hostname}/api/v3"
+        )
+        self.cache: dict[str, tuple[str | None, Any]] = {}
+
+    def get(self, endpoint: str) -> Any:
+        url = f"{self.rest_base}/{endpoint.lstrip('/')}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.token}",
+            "X-GitHub-Api-Version": API_VERSION,
+            "User-Agent": "dcjanus-github-actions-wait",
+        }
+        cached = self.cache.get(url)
+        if cached and cached[0]:
+            headers["If-None-Match"] = cached[0]
+        response = self.transport.request(url, headers)
+        if response.status == 304:
+            if cached is None:
+                raise RetryableApiError("GitHub API returned 304 without cached data")
+            return cached[1]
+        if response.status in TRANSIENT_STATUS or is_rate_limited(response):
+            raise RetryableApiError(
+                f"GitHub API temporarily returned HTTP {response.status}",
+                retry_after=parse_retry_after(response.headers),
+            )
+        if not 200 <= response.status < 300:
+            raise ApiError(f"GitHub API returned HTTP {response.status} for {endpoint}")
+        try:
+            payload = json.loads(response.body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ApiError("GitHub API returned invalid JSON") from error
+        etag = header_value(response.headers, "etag")
+        self.cache[url] = (etag, payload)
+        return payload
+
+
+def header_value(headers: dict[str, str], name: str) -> str | None:
+    return next((value for key, value in headers.items() if key.lower() == name), None)
+
+
+def parse_retry_after(headers: dict[str, str]) -> float | None:
+    value = header_value(headers, "retry-after")
+    if value is not None:
+        try:
+            return max(0.0, float(value))
+        except ValueError:
+            pass
+    reset = header_value(headers, "x-ratelimit-reset")
+    if reset is None:
+        return None
+    try:
+        return max(0.0, float(reset) - time.time())
+    except ValueError:
+        return None
+
+
+def is_rate_limited(response: RawResponse) -> bool:
+    if response.status != 403:
+        return False
+    return (
+        header_value(response.headers, "retry-after") is not None
+        or header_value(response.headers, "x-ratelimit-remaining") == "0"
+    )
+
+
+def parse_repo(value: str, hostname: str | None = None) -> RepoRef:
+    raw = value.strip()
+    selected_host = hostname or os.environ.get("GH_HOST")
+    if "://" in raw:
+        parsed = urlparse(raw)
+        selected_host = selected_host or parsed.hostname
+        raw = parsed.path
+    raw = raw.removesuffix(".git").strip("/")
+    parts = raw.split("/")
+    if len(parts) == 3 and hostname is None:
+        selected_host, owner, name = parts
+    elif len(parts) == 2:
+        owner, name = parts
+    else:
+        raise WaitError("repo must be OWNER/REPO, HOST/OWNER/REPO, or a repository URL")
+    if not owner or not name:
+        raise WaitError("repository owner and name must not be empty")
+    return RepoRef(owner, name, selected_host or "github.com")
+
+
+def resolve_token(hostname: str) -> str:
+    names = (
+        ("GH_TOKEN", "GITHUB_TOKEN")
+        if hostname == "github.com"
+        else (
+            "GH_ENTERPRISE_TOKEN",
+            "GITHUB_ENTERPRISE_TOKEN",
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+        )
+    )
+    for name in names:
+        if token := os.environ.get(name, "").strip():
+            return token
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token", "--hostname", hostname],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as error:
+        raise WaitError("no GitHub token found and gh is not installed") from error
+    if result.returncode != 0 or not result.stdout.strip():
+        raise WaitError(f"no GitHub authentication available for {hostname}")
+    return result.stdout.strip()
+
+
+def conclusion_state(status: str | None, conclusion: str | None) -> str:
+    if status != "completed" and conclusion is None:
+        return "pending"
+    if conclusion in SUCCESS_CONCLUSIONS:
+        return "success"
+    if conclusion in CANCELLED_CONCLUSIONS:
+        return "cancelled"
+    if conclusion in FAILURE_CONCLUSIONS:
+        return "failure"
+    return "pending"
+
+
+def selected_items(
+    items: Sequence[dict[str, Any]], names: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    if not names:
+        return list(items)
+    return [
+        item
+        for item in items
+        if any(
+            fnmatch.fnmatchcase(str(item.get("name", "")), pattern) for pattern in names
+        )
+    ]
+
+
+def aggregate_items(
+    items: Sequence[dict[str, Any]], *, fail_fast: bool = False
+) -> tuple[str, list[dict[str, str]]]:
+    normalized = [
+        {
+            "name": str(item.get("name", "")),
+            "state": conclusion_state(item.get("status"), item.get("conclusion")),
+        }
+        for item in items
+    ]
+    states = {item["state"] for item in normalized}
+    if not normalized:
+        return "pending", normalized
+    if fail_fast and "failure" in states:
+        return "failure", normalized
+    if fail_fast and "cancelled" in states:
+        return "cancelled", normalized
+    if "pending" in states:
+        return "pending", normalized
+    if "failure" in states:
+        return "failure", normalized
+    if "cancelled" in states:
+        return "cancelled", normalized
+    return "success", normalized
+
+
+def repo_endpoint(api: Any, suffix: str) -> str:
+    return f"repos/{api.repo.full_name}/{suffix}"
+
+
+def collection(api: Any, endpoint: str, key: str) -> list[dict[str, Any]]:
+    payload = api.get(endpoint)
+    items = list(payload.get(key, []))
+    total = int(payload.get("total_count", len(items)))
+    page = 2
+    while len(items) < total:
+        separator = "&" if "?" in endpoint else "?"
+        payload = api.get(f"{endpoint}{separator}page={page}")
+        page_items = payload.get(key, [])
+        if not page_items:
+            break
+        items.extend(page_items)
+        page += 1
+    return items
+
+
+def snapshot(api: Any, target: Target, *, fail_fast: bool) -> dict[str, Any]:
+    if target.kind == "run" and not target.names:
+        item = api.get(repo_endpoint(api, f"actions/runs/{target.identifier}"))
+        status = item.get("status")
+        conclusion = item.get("conclusion")
+        return {
+            "state": conclusion_state(status, conclusion),
+            "status": status,
+            "conclusion": conclusion,
+            "name": item.get("name"),
+            "url": item.get("html_url"),
+        }
+    if target.kind == "job":
+        item = api.get(repo_endpoint(api, f"actions/jobs/{target.identifier}"))
+        status = item.get("status")
+        conclusion = item.get("conclusion")
+        return {
+            "state": conclusion_state(status, conclusion),
+            "status": status,
+            "conclusion": conclusion,
+            "name": item.get("name"),
+            "url": item.get("html_url"),
+        }
+    if target.kind == "run":
+        items = collection(
+            api,
+            repo_endpoint(api, f"actions/runs/{target.identifier}/jobs?per_page=100"),
+            "jobs",
+        )
+        items = selected_items(items, target.names)
+        state, normalized = aggregate_items(items)
+        return {
+            "state": state,
+            "status": "completed" if state != "pending" else "in_progress",
+            "items": normalized,
+        }
+    pull = api.get(repo_endpoint(api, f"pulls/{target.identifier}"))
+    sha = pull["head"]["sha"]
+    checks = collection(
+        api,
+        repo_endpoint(api, f"commits/{sha}/check-runs?per_page=100"),
+        "check_runs",
+    )
+    statuses = api.get(repo_endpoint(api, f"commits/{sha}/status"))
+    items = list(checks)
+    items.extend(
+        {
+            "name": item.get("context", ""),
+            "status": "completed" if item.get("state") != "pending" else "in_progress",
+            "conclusion": item.get("state"),
+        }
+        for item in statuses.get("statuses", [])
+    )
+    items = selected_items(items, target.names)
+    state, normalized = aggregate_items(items, fail_fast=fail_fast)
+    return {
+        "state": state,
+        "status": "completed" if state != "pending" else "in_progress",
+        "items": normalized,
+        "sha": sha,
+    }
+
+
+class Emitter:
+    def __init__(
+        self,
+        output_format: str,
+        stream: TextIO,
+        *,
+        wall_time: Callable[[], float] = time.time,
+    ) -> None:
+        self.output_format = output_format
+        self.stream = stream
+        self.wall_time = wall_time
+
+    def emit(self, event: str, target: Target, **fields: Any) -> None:
+        payload = {
+            "event": event,
+            "time": datetime.fromtimestamp(self.wall_time(), UTC).isoformat(),
+            "target": target.kind,
+            "id": target.identifier,
+            **fields,
+        }
+        if self.output_format == "ndjson":
+            print(
+                json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+                file=self.stream,
+                flush=True,
+            )
+            return
+        detail = fields.get("state") or fields.get("message") or ""
+        status = fields.get("status")
+        if status and status != detail:
+            detail = f"{detail} ({status})"
+        print(
+            f"[{payload['time']}] {target.kind} {target.identifier}: {event} {detail}".rstrip(),
+            file=self.stream,
+            flush=True,
+        )
+
+
+def terminal_exit(state: str) -> int | None:
+    return {
+        "success": EXIT_SUCCESS,
+        "failure": EXIT_FAILURE,
+        "cancelled": EXIT_CANCELLED,
+    }.get(state)
+
+
+def wait_for_target(
+    api: Any,
+    target: Target,
+    *,
+    interval: float,
+    timeout: float,
+    fail_fast: bool,
+    emitter: Emitter,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> int:
+    started = monotonic()
+    previous: str | None = None
+    previous_error: str | None = None
+    while True:
+        if monotonic() - started >= timeout:
+            emitter.emit("timeout", target, state="timeout")
+            return EXIT_TIMEOUT
+        try:
+            current = snapshot(api, target, fail_fast=fail_fast)
+            signature = json.dumps(current, sort_keys=True, separators=(",", ":"))
+            if signature != previous:
+                emitter.emit("state", target, **current)
+                previous = signature
+            previous_error = None
+            if (code := terminal_exit(current["state"])) is not None:
+                return code
+            delay = interval
+        except RetryableApiError as error:
+            signature = str(error)
+            if signature != previous_error:
+                emitter.emit(
+                    "retry",
+                    target,
+                    message=signature,
+                    retry_after=error.retry_after,
+                )
+                previous_error = signature
+            delay = error.retry_after if error.retry_after is not None else interval
+        remaining = timeout - (monotonic() - started)
+        sleep(min(delay, max(0.0, remaining)))
+
+
+def run_guarded(
+    operation: Callable[[], int], emitter: Emitter, target: Target | None = None
+) -> int:
+    selected = target or Target("unknown", 0)
+    try:
+        return operation()
+    except KeyboardInterrupt:
+        emitter.emit("interrupted", selected, state="interrupted")
+        return EXIT_INTERRUPTED
+    except (ApiError, WaitError) as error:
+        emitter.emit("error", selected, message=str(error), state="error")
+        return EXIT_API_ERROR
+
+
+def install_signal_handlers() -> None:
+    def interrupt(signum: int, frame: Any) -> None:
+        del signum, frame
+        raise SignalInterrupt
+
+    signal.signal(signal.SIGTERM, interrupt)
+
+
+def parse_duration(value: str) -> float:
+    multipliers = {"s": 1, "m": 60, "h": 3600}
+    suffix = value[-1:].lower()
+    number = value[:-1] if suffix in multipliers else value
+    try:
+        seconds = float(number) * multipliers.get(suffix, 1)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "duration must be seconds or use s, m, h"
+        ) from error
+    if seconds <= 0:
+        raise argparse.ArgumentTypeError("duration must be greater than zero")
+    return seconds
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="OWNER/REPO or HOST/OWNER/REPO")
+    targets = parser.add_mutually_exclusive_group(required=True)
+    targets.add_argument("--run", type=int, metavar="ID")
+    targets.add_argument("--job", type=int, metavar="ID")
+    targets.add_argument("--pr", type=int, metavar="NUMBER")
+    parser.add_argument("--job-name", action="append", default=[], metavar="GLOB")
+    parser.add_argument("--check", action="append", default=[], metavar="GLOB")
+    parser.add_argument("--fail-fast", action="store_true")
+    parser.add_argument("--interval", type=parse_duration, default=30.0)
+    parser.add_argument("--timeout", type=parse_duration, default=1800.0)
+    parser.add_argument("--format", choices=("human", "ndjson"), default="human")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    install_signal_handlers()
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.job_name and args.run is None:
+        parser.error("--job-name requires --run")
+    if args.check and args.pr is None:
+        parser.error("--check requires --pr")
+    if args.fail_fast and args.pr is None:
+        parser.error("--fail-fast requires --pr")
+    repo = parse_repo(args.repo)
+    if args.run is not None:
+        target = Target("run", args.run, tuple(args.job_name))
+    elif args.job is not None:
+        target = Target("job", args.job)
+    else:
+        target = Target("pr", args.pr, tuple(args.check))
+    emitter = Emitter(args.format, sys.stdout)
+
+    def operation() -> int:
+        api = GitHubApi(repo, resolve_token(repo.hostname))
+        return wait_for_target(
+            api,
+            target,
+            interval=args.interval,
+            timeout=args.timeout,
+            fail_fast=args.fail_fast,
+            emitter=emitter,
+        )
+
+    return run_guarded(operation, emitter, target)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/dcjanus/skills/github-cli/scripts/github_actions_wait.py
+++ b/plugins/dcjanus/skills/github-cli/scripts/github_actions_wait.py
@@ -201,7 +201,7 @@ def is_rate_limited(response: RawResponse) -> bool:
 
 def parse_repo(value: str, hostname: str | None = None) -> RepoRef:
     raw = value.strip()
-    selected_host = hostname or os.environ.get("GH_HOST")
+    selected_host = hostname
     if "://" in raw:
         parsed = urlparse(raw)
         selected_host = selected_host or parsed.hostname
@@ -216,23 +216,14 @@ def parse_repo(value: str, hostname: str | None = None) -> RepoRef:
         raise WaitError("repo must be OWNER/REPO, HOST/OWNER/REPO, or a repository URL")
     if not owner or not name:
         raise WaitError("repository owner and name must not be empty")
-    return RepoRef(owner, name, selected_host or "github.com")
+    return RepoRef(
+        owner, name, selected_host or os.environ.get("GH_HOST") or "github.com"
+    )
 
 
 def resolve_token(hostname: str) -> str:
-    names = (
-        ("GH_TOKEN", "GITHUB_TOKEN")
-        if hostname == "github.com"
-        else (
-            "GH_ENTERPRISE_TOKEN",
-            "GITHUB_ENTERPRISE_TOKEN",
-            "GH_TOKEN",
-            "GITHUB_TOKEN",
-        )
-    )
-    for name in names:
-        if token := os.environ.get(name, "").strip():
-            return token
+    if token := os.environ.get("GH_TOKEN", "").strip():
+        return token
     try:
         result = subprocess.run(
             ["gh", "auth", "token", "--hostname", hostname],

--- a/plugins/dcjanus/skills/github-cli/scripts/tests/test_github_actions_wait.py
+++ b/plugins/dcjanus/skills/github-cli/scripts/tests/test_github_actions_wait.py
@@ -265,7 +265,7 @@ def test_primary_rate_limit_403_is_retryable() -> None:
 def test_token_is_redacted_from_api_errors_and_ndjson() -> None:
     token = "super-secret-token"
     transport = github_actions_wait.FakeableTransport(
-        [github_actions_wait.RawResponse(401, {}, token.encode())]
+        [github_actions_wait.RawResponse(401, {}, token.encode())] * 2
     )
     api = github_actions_wait.GitHubApi(
         github_actions_wait.RepoRef("acme", "widgets", "github.com"),
@@ -275,6 +275,14 @@ def test_token_is_redacted_from_api_errors_and_ndjson() -> None:
     with pytest.raises(github_actions_wait.ApiError) as error:
         api.get("example")
     assert token not in str(error.value)
+
+    stream = io.StringIO()
+    emitter = github_actions_wait.Emitter("ndjson", stream, wall_time=lambda: 0)
+    assert (
+        github_actions_wait.run_guarded(lambda: api.get("example"), emitter)
+        == github_actions_wait.EXIT_API_ERROR
+    )
+    assert token not in stream.getvalue()
 
 
 def test_keyboard_interrupt_returns_interrupted_exit_code() -> None:
@@ -296,3 +304,13 @@ def test_enterprise_api_base_and_host_environment(
 
     assert repo.hostname == "github.example.com"
     assert api.rest_base == "https://github.example.com/api/v3"
+
+
+def test_explicit_repository_url_takes_priority_over_gh_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_HOST", "wrong.example.com")
+
+    repo = github_actions_wait.parse_repo("https://github.example.com/acme/widgets")
+
+    assert repo.hostname == "github.example.com"

--- a/plugins/dcjanus/skills/github-cli/scripts/tests/test_github_actions_wait.py
+++ b/plugins/dcjanus/skills/github-cli/scripts/tests/test_github_actions_wait.py
@@ -314,3 +314,21 @@ def test_explicit_repository_url_takes_priority_over_gh_host(
     repo = github_actions_wait.parse_repo("https://github.example.com/acme/widgets")
 
     assert repo.hostname == "github.example.com"
+
+
+def test_gh_token_takes_priority_over_github_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "gh-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
+
+    assert github_actions_wait.resolve_token("github.com") == "gh-token"
+
+
+def test_github_token_is_used_when_gh_token_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
+
+    assert github_actions_wait.resolve_token("github.com") == "github-token"

--- a/plugins/dcjanus/skills/github-cli/scripts/tests/test_github_actions_wait.py
+++ b/plugins/dcjanus/skills/github-cli/scripts/tests/test_github_actions_wait.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "github_actions_wait.py"
+SPEC = importlib.util.spec_from_file_location("github_actions_wait", SCRIPT_PATH)
+assert SPEC is not None
+github_actions_wait = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = github_actions_wait
+SPEC.loader.exec_module(github_actions_wait)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeApi:
+    def __init__(self, responses: list[object]) -> None:
+        self.repo = github_actions_wait.RepoRef("acme", "widgets", "github.com")
+        self.responses = iter(responses)
+        self.calls: list[str] = []
+
+    def get(self, endpoint: str) -> object:
+        self.calls.append(endpoint)
+        response = next(self.responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def run_wait(
+    responses: list[object],
+    *,
+    target: github_actions_wait.Target | None = None,
+    timeout: float = 30,
+    output_format: str = "ndjson",
+    fail_fast: bool = False,
+) -> tuple[int, list[dict[str, object]], FakeApi]:
+    stream = io.StringIO()
+    clock = FakeClock()
+    api = FakeApi(responses)
+    emitter = github_actions_wait.Emitter(output_format, stream, wall_time=lambda: 0)
+    code = github_actions_wait.wait_for_target(
+        api,
+        target or github_actions_wait.Target("run", 123),
+        interval=1,
+        timeout=timeout,
+        fail_fast=fail_fast,
+        emitter=emitter,
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+    events = [json.loads(line) for line in stream.getvalue().splitlines()]
+    return code, events, api
+
+
+def test_run_queued_to_in_progress_to_success() -> None:
+    code, events, _ = run_wait(
+        [
+            {"id": 123, "status": "queued", "conclusion": None},
+            {"id": 123, "status": "in_progress", "conclusion": None},
+            {"id": 123, "status": "completed", "conclusion": "success"},
+        ]
+    )
+
+    assert code == github_actions_wait.EXIT_SUCCESS
+    assert [event["state"] for event in events] == [
+        "pending",
+        "pending",
+        "success",
+    ]
+    assert [event["status"] for event in events] == [
+        "queued",
+        "in_progress",
+        "completed",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("conclusion", "expected"),
+    [("failure", 1), ("cancelled", 3)],
+)
+def test_run_terminal_exit_codes(conclusion: str, expected: int) -> None:
+    code, events, _ = run_wait(
+        [{"id": 123, "status": "completed", "conclusion": conclusion}]
+    )
+
+    assert code == expected
+    assert events[-1]["state"] == conclusion
+
+
+def test_timeout_has_stable_exit_code() -> None:
+    code, events, _ = run_wait(
+        [{"id": 123, "status": "queued", "conclusion": None}] * 4,
+        timeout=2,
+    )
+
+    assert code == github_actions_wait.EXIT_TIMEOUT
+    assert events[-1]["event"] == "timeout"
+
+
+def test_unchanged_state_is_not_repeated() -> None:
+    code, events, _ = run_wait(
+        [
+            {"id": 123, "status": "queued", "conclusion": None},
+            {"id": 123, "status": "queued", "conclusion": None},
+            {"id": 123, "status": "completed", "conclusion": "success"},
+        ]
+    )
+
+    assert code == 0
+    assert [event["event"] for event in events] == ["state", "state"]
+
+
+def test_run_job_name_filter_and_pr_check_filter() -> None:
+    jobs = {
+        "jobs": [
+            {"id": 1, "name": "lint", "status": "completed", "conclusion": "success"},
+            {
+                "id": 2,
+                "name": "test-linux",
+                "status": "completed",
+                "conclusion": "success",
+            },
+        ]
+    }
+    code, events, api = run_wait(
+        [jobs], target=github_actions_wait.Target("run", 123, names=("test-*",))
+    )
+    assert code == 0
+    assert events[-1]["items"] == [{"name": "test-linux", "state": "success"}]
+    assert api.calls == ["repos/acme/widgets/actions/runs/123/jobs?per_page=100"]
+
+    pull = {"head": {"sha": "abc"}}
+    checks = {
+        "check_runs": [
+            {"id": 3, "name": "lint", "status": "completed", "conclusion": "failure"},
+            {
+                "id": 4,
+                "name": "test-linux",
+                "status": "completed",
+                "conclusion": "success",
+            },
+        ]
+    }
+    statuses = {"statuses": []}
+    code, events, _ = run_wait(
+        [pull, checks, statuses],
+        target=github_actions_wait.Target("pr", 9, names=("test-*",)),
+    )
+    assert code == 0
+    assert events[-1]["items"] == [{"name": "test-linux", "state": "success"}]
+
+
+def test_pr_fail_fast_stops_on_first_failure() -> None:
+    pull = {"head": {"sha": "abc"}}
+    checks = {
+        "check_runs": [
+            {"id": 1, "name": "lint", "status": "completed", "conclusion": "failure"},
+            {"id": 2, "name": "test", "status": "in_progress", "conclusion": None},
+        ]
+    }
+    code, events, _ = run_wait(
+        [pull, checks, {"statuses": []}],
+        target=github_actions_wait.Target("pr", 9),
+        fail_fast=True,
+    )
+
+    assert code == github_actions_wait.EXIT_FAILURE
+    assert events[-1]["state"] == "failure"
+
+
+def test_temporary_api_error_is_retried_without_duplicate_noise() -> None:
+    error = github_actions_wait.RetryableApiError("temporary", retry_after=2)
+    code, events, _ = run_wait(
+        [
+            error,
+            github_actions_wait.RetryableApiError("temporary", retry_after=2),
+            {"id": 123, "status": "completed", "conclusion": "success"},
+        ]
+    )
+
+    assert code == 0
+    assert [event["event"] for event in events] == ["retry", "state"]
+    assert events[0]["retry_after"] == 2
+
+
+def test_etag_304_reuses_cached_json() -> None:
+    transport = github_actions_wait.FakeableTransport(
+        [
+            github_actions_wait.RawResponse(
+                200, {"ETag": '"v1"'}, b'{"status":"queued"}'
+            ),
+            github_actions_wait.RawResponse(304, {}, b""),
+        ]
+    )
+    api = github_actions_wait.GitHubApi(
+        github_actions_wait.RepoRef("acme", "widgets", "github.com"),
+        "secret-token",
+        transport=transport,
+    )
+
+    assert api.get("example") == {"status": "queued"}
+    assert api.get("example") == {"status": "queued"}
+    assert transport.requests[1][1]["If-None-Match"] == '"v1"'
+
+
+def test_rate_limit_response_exposes_retry_after_without_body() -> None:
+    transport = github_actions_wait.FakeableTransport(
+        [
+            github_actions_wait.RawResponse(
+                429,
+                {"Retry-After": "7"},
+                b'{"message":"secret response detail"}',
+            )
+        ]
+    )
+    api = github_actions_wait.GitHubApi(
+        github_actions_wait.RepoRef("acme", "widgets", "github.com"),
+        "token",
+        transport=transport,
+    )
+
+    with pytest.raises(github_actions_wait.RetryableApiError) as error:
+        api.get("example")
+    assert error.value.retry_after == 7
+    assert "secret response detail" not in str(error.value)
+
+
+def test_primary_rate_limit_403_is_retryable() -> None:
+    transport = github_actions_wait.FakeableTransport(
+        [
+            github_actions_wait.RawResponse(
+                403,
+                {"X-RateLimit-Remaining": "0", "Retry-After": "11"},
+                b"{}",
+            )
+        ]
+    )
+    api = github_actions_wait.GitHubApi(
+        github_actions_wait.RepoRef("acme", "widgets", "github.com"),
+        "token",
+        transport=transport,
+    )
+
+    with pytest.raises(github_actions_wait.RetryableApiError) as error:
+        api.get("example")
+    assert error.value.retry_after == 11
+
+
+def test_token_is_redacted_from_api_errors_and_ndjson() -> None:
+    token = "super-secret-token"
+    transport = github_actions_wait.FakeableTransport(
+        [github_actions_wait.RawResponse(401, {}, token.encode())]
+    )
+    api = github_actions_wait.GitHubApi(
+        github_actions_wait.RepoRef("acme", "widgets", "github.com"),
+        token,
+        transport=transport,
+    )
+    with pytest.raises(github_actions_wait.ApiError) as error:
+        api.get("example")
+    assert token not in str(error.value)
+
+
+def test_keyboard_interrupt_returns_interrupted_exit_code() -> None:
+    stream = io.StringIO()
+    emitter = github_actions_wait.Emitter("ndjson", stream, wall_time=lambda: 0)
+    code = github_actions_wait.run_guarded(
+        lambda: (_ for _ in ()).throw(KeyboardInterrupt()), emitter
+    )
+    assert code == github_actions_wait.EXIT_INTERRUPTED
+    assert json.loads(stream.getvalue())["event"] == "interrupted"
+
+
+def test_enterprise_api_base_and_host_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_HOST", "github.example.com")
+    repo = github_actions_wait.parse_repo("acme/widgets")
+    api = github_actions_wait.GitHubApi(repo, "token", transport=FakeApi([]))
+
+    assert repo.hostname == "github.example.com"
+    assert api.rest_base == "https://github.example.com/api/v3"

--- a/plugins/dcjanus/skills/repository-workflow/scripts/commit_from_yaml.py
+++ b/plugins/dcjanus/skills/repository-workflow/scripts/commit_from_yaml.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.14"
 # dependencies = [
-#     "openai-codex>=0.147.0",
+#     "openai-codex>=0.154.0",
 #     "pydantic>=2.13.5",
 #     "pyyaml>=6.0.3",
 #     "typer>=0.27.2",

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -11,7 +11,7 @@
 #     "httpxyz>=0.42.1",
 #     "kittytgp>=0.0.2",
 #     "markdown-it-py>=4.2.0",
-#     "openai-codex>=0.147.0",
+#     "openai-codex>=0.154.0",
 #     "pydantic>=2.13.5",
 #     "pytest>=9.1.1",
 #     "pyyaml>=6.0.3",


### PR DESCRIPTION
## Why

Agent 等待 GitHub Actions 时目前需要手写轮询，`gh run watch` 和 `gh pr checks --watch` 也无法同时提供单 Job、低噪声事件、统一超时和稳定机器退出码。

## What

- 为 workflow run、单个 job 和 PR checks 增加统一的只读等待脚本，支持名称 glob、PR fail-fast、超时以及 human/NDJSON 输出。
- 只在状态快照变化时输出，并处理临时 API 错误、Rate Limit、`Retry-After`、ETag/304、GitHub Enterprise host 与中断信号；认证按 GitHub CLI 风格依次读取 `GH_TOKEN`、`GITHUB_TOKEN`，否则回退到遵循 host 和 `GH_CONFIG_DIR` 的 `gh auth token`。
- 新增完整使用与状态契约 reference，并让 `SKILL.md` 将 Agent 阻塞等待路由到统一入口。
- 将既有 PEP 723 脚本的 `openai-codex` 最低版本更新到 0.154.0，修复外部最新版漂移触发的依赖门禁失败。

## Validation

- 在脚本不存在时，新增行为测试因入口缺失而于测试收集阶段失败；实现后相同测试覆盖 queued → in progress → success、失败、取消、超时、fail-fast、去重、筛选、重试、Rate Limit、ETag/304、脱敏、中断和 Enterprise API base，完整仓库测试通过。
- 从本 PR 分支通过隔离的 Git marketplace 完成 plugin 安装；安装副本与源码脚本逐字节一致且可执行。
- 对仓库既有的成功 workflow run 进行真实只读等待，脚本输出单条 `success` NDJSON 事件；GitHub.com 实际 run 响应包含 ETag。
