### PR TITLE
feat(chatgpt-usage): 在 SVG 中显示精确重置时间

### DIFF
--- a/scripts/chatgpt_usage.py
+++ b/scripts/chatgpt_usage.py
@@ -1832,6 +1832,15 @@ def _remaining_text(seconds: float | None) -> str:
     return "".join(parts)
 
 
+def _svg_reset_text(window: UsageWindow, progress: WindowProgress) -> str:
+    """格式化 SVG 中的相对与绝对重置时间。"""
+    relative = f"{_remaining_text(progress.remaining_seconds)}后重置"
+    if window.resets_at is None:
+        return relative
+    reset_at = datetime.fromtimestamp(window.resets_at).astimezone()
+    return f"{relative}（{reset_at:%m-%d %H:%M}）"
+
+
 def _catch_up_seconds(window: UsageWindow, progress: WindowProgress) -> float | None:
     """返回暂停使用后额度进度与时间持平所需秒数。"""
     if (
@@ -2349,7 +2358,7 @@ def _render_compact_usage_svg(
                 )
             parts.extend(
                 [
-                    f'<text x="{track_x + track_width + 24}" y="{row_y + 19}" class="muted" font-size="13">{_svg_text(_remaining_text(progress.remaining_seconds))}后重置</text>',
+                    f'<text x="{track_x + track_width + 24}" y="{row_y + 19}" class="muted" font-size="13">{_svg_text(_svg_reset_text(window, progress))}</text>',
                     f'<rect x="{SVG_WIDTH - margin - 214}" y="{row_y - 4}" width="190" height="34" rx="17" fill="{pace_color}" fill-opacity="0.13"/>',
                     f'<text x="{SVG_WIDTH - margin - 119}" y="{row_y + 18}" text-anchor="middle" fill="{pace_color}" font-size="13" font-weight="700">{_svg_text(relation)}</text>',
                 ]
@@ -2527,7 +2536,7 @@ def render_usage_svg(
   <rect x="{badge_x}" y="{panel_y + 12}" width="{badge_width}" height="32" rx="16" fill="{pace_color}" fill-opacity="0.13"/>
   <text x="{badge_x + badge_width / 2}" y="{panel_y + 34}" text-anchor="middle" fill="{pace_color}" font-size="14" font-weight="700">{_svg_text(relation_text)}</text>
   {_svg_comparison_rail(progress, x=rail_x, y=panel_y + 83, width=rail_width)}
-  <text x="{panel_x + 22}" y="{panel_y + 140}" class="muted" font-size="12">距离重置 {_svg_text(_remaining_text(progress.remaining_seconds))}</text>'''
+  <text x="{panel_x + 22}" y="{panel_y + 140}" class="muted" font-size="12">{_svg_text(_svg_reset_text(window, progress))}</text>'''
             )
             if verbose and window.resets_at is not None:
                 reset_text = (

--- a/scripts/tests/test_chatgpt_usage.py
+++ b/scripts/tests/test_chatgpt_usage.py
@@ -430,6 +430,28 @@ class RenderUsageTests(unittest.TestCase):
         self.assertNotIn('data-role="time-marker"', svg)
         self.assertNotIn("stroke-dasharray", svg)
         self.assertIn("额度充足，节奏安全", svg)
+        reset_at = datetime.fromtimestamp(
+            self.buckets[0].windows[0].resets_at or 0
+        ).astimezone()
+        self.assertIn(f"2小时30分钟后重置（{reset_at:%m-%d %H:%M}）", svg)
+
+    def test_compact_svg_includes_exact_reset_time(self) -> None:
+        history = chatgpt_usage.UsageHistory(
+            days=(),
+            scan=chatgpt_usage.ScanStats(0, 0, 0, 0),
+        )
+
+        svg = chatgpt_usage.render_usage_svg(
+            self.buckets,
+            self.now,
+            history=history,
+            verbose=False,
+        )
+
+        reset_at = datetime.fromtimestamp(
+            self.buckets[0].windows[0].resets_at or 0
+        ).astimezone()
+        self.assertIn(f"2小时30分钟后重置（{reset_at:%m-%d %H:%M}）", svg)
 
     def test_svg_is_rasterized_in_process(self) -> None:
         svg = chatgpt_usage.render_usage_svg(self.buckets, self.now, verbose=False)


### PR DESCRIPTION
## Why

SVG 看板目前只展示距离重置的相对时长，无法直接确认具体的本地重置时刻。

## What

- 在相对重置时长后补充精确到分钟的本地时间，例如 `6天23小时后重置（09-19 16:10）`。
- 统一覆盖紧凑 SVG 与详细 SVG 布局，纯文本输出保持不变。
- 增加两种 SVG 布局的回归测试。
