### PR TITLE
feat(repository-workflow)!: 支持在提交 YAML 中控制 Assisted-by

### DIFF
--- a/plugins/dcjanus/skills/repository-workflow/SKILL.md
+++ b/plugins/dcjanus/skills/repository-workflow/SKILL.md
@@ -43,17 +43,20 @@ description: 处理从本地 Git 变更到 GitHub/GitLab 协作发布的完整�
   && rm -- /tmp/commit.yaml
 ```
 
-脚本默认从当前 Codex thread 自动解析模型并生成 `Assisted-by: Codex:<model>`。自动探测不可用时只能显式选择以下一种方式，不得猜测模型：
+脚本默认从当前 Codex thread 自动解析模型并生成 `Assisted-by: Codex:<model>`。在 opencode 等非 Codex Agent 下运行时，无论是否自动探测到模型，都必须用 `--agent` 覆盖 Agent 名，避免写出错误的来源标识；自动探测不可用时再显式选择以下一种方式，不得猜测模型：
 
 ```bash
 ./scripts/commit_from_yaml.py /tmp/commit.yaml \
   --repo /path/to/repository --model gpt-5.6-sol
 
 ./scripts/commit_from_yaml.py /tmp/commit.yaml \
+  --repo /path/to/repository --agent opencode --model deepseek-v4.1-flash
+
+./scripts/commit_from_yaml.py /tmp/commit.yaml \
   --repo /path/to/repository --skip-assisted-by
 ```
 
-`--model` 跳过自动探测但仍生成 trailer；`--skip-assisted-by` 同时跳过探测和 trailer。两者互斥，后者只用于确实无法获得模型信息的场景。
+`--agent` 覆盖 `Assisted-by` 的 Agent 前缀（默认 `Codex`，不能为空）；`--model` 跳过自动探测但仍生成 trailer；`--skip-assisted-by` 同时跳过探测和 trailer。`--model` 与 `--skip-assisted-by` 互斥，后者只用于确实无法获得模型信息的场景。
 
 4. YAML 的 `paths` 非空时，脚本会把每一项原样作为 Git pathspec 传给 Git，自动让匹配到的未跟踪文件进入 intent-to-add 状态，再使用 `git commit --only` 限定提交范围；调用方无需预先 stage。通配符由 Git 而不是 shell 展开，YAML 中应使用引号；需要让 `*` 不跨越目录分隔符时，使用 `:(glob)` 与 `**` 明确表达层级。若提交失败，脚本会清理自己创建的 intent-to-add 条目。`paths` 为空时提交当前 index，也可用于已经解决冲突的 merge commit。
 5. 脚本会在提交前后校验正文、breaking 标记和 trailer；任何字段中的字面量 `\\n` 都会失败。提交后仍需回读范围与工作区：

--- a/plugins/dcjanus/skills/repository-workflow/SKILL.md
+++ b/plugins/dcjanus/skills/repository-workflow/SKILL.md
@@ -43,20 +43,18 @@ description: 处理从本地 Git 变更到 GitHub/GitLab 协作发布的完整�
   && rm -- /tmp/commit.yaml
 ```
 
-脚本默认从当前 Codex thread 自动解析模型并生成 `Assisted-by: Codex:<model>`。在 opencode 等非 Codex Agent 下运行时，无论是否自动探测到模型，都必须用 `--agent` 覆盖 Agent 名，避免写出错误的来源标识；自动探测不可用时再显式选择以下一种方式，不得猜测模型：
+脚本默认从当前 Codex thread 自动解析模型并生成 `Assisted-by: Codex:<model>`。需要覆盖默认行为时，把 `assisted_by` 写进提交 YAML，而不是改用命令行参数，便于审查：
 
-```bash
-./scripts/commit_from_yaml.py /tmp/commit.yaml \
-  --repo /path/to/repository --model gpt-5.6-sol
-
-./scripts/commit_from_yaml.py /tmp/commit.yaml \
-  --repo /path/to/repository --agent opencode --model deepseek-v4.1-flash
-
-./scripts/commit_from_yaml.py /tmp/commit.yaml \
-  --repo /path/to/repository --skip-assisted-by
+```yaml
+# 在 opencode 等非 Codex Agent 下显式指定 Agent 与模型
+assisted_by:
+  agent: opencode
+  model: deepseek-v4.1-flash
 ```
 
-`--agent` 覆盖 `Assisted-by` 的 Agent 前缀（默认 `Codex`，不能为空）；`--model` 跳过自动探测但仍生成 trailer；`--skip-assisted-by` 同时跳过探测和 trailer。`--model` 与 `--skip-assisted-by` 互斥，后者只用于确实无法获得模型信息的场景。
+- `assisted_by.agent` 覆盖 Agent 前缀（默认 `Codex`，不能为空）。
+- `assisted_by.model` 指定模型并跳过自动探测；缺省时自动探测当前 Codex thread 使用的模型，不得猜测。
+- `assisted_by: false` 跳过探测且不添加 `Assisted-by` trailer，只用于确实无法获得模型信息的场景。
 
 4. YAML 的 `paths` 非空时，脚本会把每一项原样作为 Git pathspec 传给 Git，自动让匹配到的未跟踪文件进入 intent-to-add 状态，再使用 `git commit --only` 限定提交范围；调用方无需预先 stage。通配符由 Git 而不是 shell 展开，YAML 中应使用引号；需要让 `*` 不跨越目录分隔符时，使用 `:(glob)` 与 `**` 明确表达层级。若提交失败，脚本会清理自己创建的 intent-to-add 条目。`paths` 为空时提交当前 index，也可用于已经解决冲突的 merge commit。
 5. 脚本会在提交前后校验正文、breaking 标记和 trailer；任何字段中的字面量 `\\n` 都会失败。提交后仍需回读范围与工作区：

--- a/plugins/dcjanus/skills/repository-workflow/SKILL.md
+++ b/plugins/dcjanus/skills/repository-workflow/SKILL.md
@@ -43,7 +43,7 @@ description: 处理从本地 Git 变更到 GitHub/GitLab 协作发布的完整�
   && rm -- /tmp/commit.yaml
 ```
 
-脚本默认从当前 Codex thread 自动解析模型并生成 `Assisted-by: Codex:<model>`。需要覆盖默认行为时，把 `assisted_by` 写进提交 YAML，而不是改用命令行参数，便于审查：
+脚本默认从当前 Codex thread 自动解析模型并生成 `Assisted-by: codex:<model>`。需要覆盖默认行为时，把 `assisted_by` 写进提交 YAML，而不是改用命令行参数，便于审查：
 
 ```yaml
 # 在 opencode 等非 Codex Agent 下显式指定 Agent 与模型
@@ -52,7 +52,7 @@ assisted_by:
   model: deepseek-v4.1-flash
 ```
 
-- `assisted_by.agent` 覆盖 Agent 前缀（默认 `Codex`，不能为空）。
+- `assisted_by.agent` 覆盖 Agent 前缀（默认 `codex`，不能为空）。
 - `assisted_by.model` 指定模型并跳过自动探测；缺省时自动探测当前 Codex thread 使用的模型，不得猜测。
 - 非 Codex 运行环境下自动探测大概率失败，此时应显式询问用户所用模型并写入 `assisted_by.model`。
 - `assisted_by: false` 跳过探测且不添加 `Assisted-by` trailer，只用于确实无法获得模型信息的场景。

--- a/plugins/dcjanus/skills/repository-workflow/SKILL.md
+++ b/plugins/dcjanus/skills/repository-workflow/SKILL.md
@@ -54,6 +54,7 @@ assisted_by:
 
 - `assisted_by.agent` 覆盖 Agent 前缀（默认 `Codex`，不能为空）。
 - `assisted_by.model` 指定模型并跳过自动探测；缺省时自动探测当前 Codex thread 使用的模型，不得猜测。
+- 非 Codex 运行环境下自动探测大概率失败，此时应显式询问用户所用模型并写入 `assisted_by.model`。
 - `assisted_by: false` 跳过探测且不添加 `Assisted-by` trailer，只用于确实无法获得模型信息的场景。
 
 4. YAML 的 `paths` 非空时，脚本会把每一项原样作为 Git pathspec 传给 Git，自动让匹配到的未跟踪文件进入 intent-to-add 状态，再使用 `git commit --only` 限定提交范围；调用方无需预先 stage。通配符由 Git 而不是 shell 展开，YAML 中应使用引号；需要让 `*` 不跨越目录分隔符时，使用 `:(glob)` 与 `**` 明确表达层级。若提交失败，脚本会清理自己创建的 intent-to-add 条目。`paths` 为空时提交当前 index，也可用于已经解决冲突的 merge commit。

--- a/plugins/dcjanus/skills/repository-workflow/references/commit-messages.md
+++ b/plugins/dcjanus/skills/repository-workflow/references/commit-messages.md
@@ -74,7 +74,7 @@ breaking_change:
 ## Trailers
 
 - 通过 YAML 的 `trailers` 添加 `Co-authored-by`、`Reviewed-by` 等结构化 trailer。
-- `Assisted-by` 由提交脚本自动探测、通过 `--model` 显式生成，或通过 `--skip-assisted-by` 明确省略。
+- `Assisted-by` 由提交脚本自动探测、通过 `--model` 和 `--agent` 显式生成，或通过 `--skip-assisted-by` 明确省略。
 - `trailers` 只用于能被 `git interpret-trailers --parse` 正确识别的普通 key；不能包含 `Assisted-by` 或 `BREAKING CHANGE`。
 - 不要用多个 `-m` 或 shell 转义手工拼接正文和 trailer block。
 - shell 命令中的提交标题或正文不要包含未安全处理的反引号。

--- a/plugins/dcjanus/skills/repository-workflow/references/commit-messages.md
+++ b/plugins/dcjanus/skills/repository-workflow/references/commit-messages.md
@@ -45,7 +45,7 @@ paths:
 - `paths` 的每一项都是仓库相对的 Git pathspec，支持字面路径、目录、`*`、`?`、字符集合以及 `:(glob)` 等 Git pathspec magic；非空时脚本自动处理匹配到的未跟踪文件，并使用 `git commit --only`，为空时提交当前 index。
 - pathspec 会原样传给 Git，不经过 shell 展开。包含通配符或 magic 时必须在 YAML 中使用引号；需要可预测的目录层级匹配时优先使用 `:(glob)`，其中 `*` 不匹配 `/`、`**` 可跨越目录。例如 `':(glob)src/**/*.py'` 会匹配 `src` 下各层级的 Python 文件。
 - `trailers` 是 `key` / `value` 结构化列表；key 仅支持字母、数字和连字符，value 必须是非空单行字符串。
-- `Assisted-by` 由脚本生成，禁止放入 `trailers`。
+- `Assisted-by` 由脚本根据顶层 `assisted_by` 覆盖项生成，禁止放入 `trailers`。
 - 所有字符串都禁止包含字面量 `\\n`；多行正文使用 YAML 的 `|` block scalar 表达。
 
 ## Breaking change
@@ -74,7 +74,7 @@ breaking_change:
 ## Trailers
 
 - 通过 YAML 的 `trailers` 添加 `Co-authored-by`、`Reviewed-by` 等结构化 trailer。
-- `Assisted-by` 由提交脚本自动探测、通过 `--model` 和 `--agent` 显式生成，或通过 `--skip-assisted-by` 明确省略。
+- `Assisted-by` 由提交脚本自动探测，或通过顶层 `assisted_by` 覆盖项控制：`agent` 指定 Agent 前缀，`model` 指定模型并跳过探测，`assisted_by: false` 明确省略 trailer。
 - `trailers` 只用于能被 `git interpret-trailers --parse` 正确识别的普通 key；不能包含 `Assisted-by` 或 `BREAKING CHANGE`。
 - 不要用多个 `-m` 或 shell 转义手工拼接正文和 trailer block。
 - shell 命令中的提交标题或正文不要包含未安全处理的反引号。

--- a/plugins/dcjanus/skills/repository-workflow/scripts/commit_from_yaml.py
+++ b/plugins/dcjanus/skills/repository-workflow/scripts/commit_from_yaml.py
@@ -21,7 +21,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Annotated, Any, Self
+from typing import Annotated, Any, Literal, Self
 
 import typer
 import yaml
@@ -146,6 +146,13 @@ class Trailer(StrictModel):
         return self
 
 
+class AssistedBy(StrictModel):
+    """Assisted-by trailer 的覆盖项。"""
+
+    agent: str = DEFAULT_AGENT_NAME
+    model: str | None = None
+
+
 class CommitSpec(StrictModel):
     """结构化提交描述。"""
 
@@ -154,6 +161,7 @@ class CommitSpec(StrictModel):
     breaking_change: BreakingChange | None = None
     trailers: list[Trailer] = Field(default_factory=list)
     paths: list[str] = Field(default_factory=list)
+    assisted_by: AssistedBy | Literal[False] | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -240,7 +248,8 @@ def require_thread_id() -> str:
     thread_id = os.environ.get("CODEX_THREAD_ID", "").strip()
     if not thread_id:
         raise CommitError(
-            "missing CODEX_THREAD_ID; use --model MODEL or --skip-assisted-by"
+            "missing CODEX_THREAD_ID; set assisted_by.model in the commit YAML "
+            "or use assisted_by: false"
         )
     return thread_id
 
@@ -255,8 +264,8 @@ def resolve_codex_bin() -> str:
     if resolved:
         return resolved
     raise CommitError(
-        "host Codex binary not found; set CODEX_BIN, use --model MODEL, "
-        "or use --skip-assisted-by"
+        "host Codex binary not found; set CODEX_BIN, set assisted_by.model "
+        "in the commit YAML, or use assisted_by: false"
     )
 
 
@@ -324,21 +333,19 @@ def resolve_model_name() -> str:
     return read_latest_model_name(Path(rollout_path))
 
 
-def assisted_by_value(
-    model: str | None, skip: bool, agent: str = DEFAULT_AGENT_NAME
-) -> str | None:
-    """根据 CLI 参数返回 Assisted-by 值。"""
+def assisted_by_value(config: AssistedBy | Literal[False] | None) -> str | None:
+    """根据 YAML 的 assisted_by 覆盖项返回 Assisted-by 值。"""
 
-    if model is not None and skip:
-        raise CommitError("--model and --skip-assisted-by are mutually exclusive")
-    if skip:
+    if config is False:
         return None
+    agent = config.agent if config is not None else DEFAULT_AGENT_NAME
+    model = config.model if config is not None else None
     agent_name = agent.strip()
     if not agent_name:
-        raise CommitError("--agent must not be empty")
+        raise CommitError("assisted_by.agent must not be empty")
     model_name = model.strip() if model is not None else resolve_model_name()
     if not model_name:
-        raise CommitError("--model must not be empty")
+        raise CommitError("assisted_by.model must not be empty")
     return f"{agent_name}:{model_name}"
 
 
@@ -435,27 +442,12 @@ def main(
     json_output: Annotated[
         bool, typer.Option("--json", help="输出机器可读 JSON。")
     ] = False,
-    model: Annotated[
-        str | None,
-        typer.Option("--model", help="显式指定模型并跳过自动探测。"),
-    ] = None,
-    agent: Annotated[
-        str,
-        typer.Option("--agent", help=f"Assisted-by 的 Agent 名（默认 {DEFAULT_AGENT_NAME}）。"),
-    ] = DEFAULT_AGENT_NAME,
-    skip_assisted_by: Annotated[
-        bool,
-        typer.Option(
-            "--skip-assisted-by",
-            help="跳过模型探测且不添加 Assisted-by trailer。",
-        ),
-    ] = False,
 ) -> None:
     """从 SPEC_FILE 创建一个结构化 Git commit。"""
 
     try:
         spec = load_spec(spec_file.read_text(encoding="utf-8"))
-        assisted_by = assisted_by_value(model, skip_assisted_by, agent)
+        assisted_by = assisted_by_value(spec.assisted_by)
         message = render_message(spec, assisted_by)
         validate_rendered_message(message, assisted_by)
         commit_sha = None

--- a/plugins/dcjanus/skills/repository-workflow/scripts/commit_from_yaml.py
+++ b/plugins/dcjanus/skills/repository-workflow/scripts/commit_from_yaml.py
@@ -30,7 +30,7 @@ from openai_codex.client import CodexClient
 from openai_codex.errors import CodexError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
-AGENT_NAME = "Codex"
+DEFAULT_AGENT_NAME = "Codex"
 CONVENTIONAL_SUBJECT = re.compile(r"^[a-z][a-z0-9-]*(?:\([^\r\n)]+\))?!?: [^\r\n]+$")
 BREAKING_SUBJECT = re.compile(r"^[a-z][a-z0-9-]*(?:\([^\r\n)]+\))?!: .+$")
 BREAKING_PREFIX = "BREAKING CHANGE:"
@@ -324,17 +324,22 @@ def resolve_model_name() -> str:
     return read_latest_model_name(Path(rollout_path))
 
 
-def assisted_by_value(model: str | None, skip: bool) -> str | None:
+def assisted_by_value(
+    model: str | None, skip: bool, agent: str = DEFAULT_AGENT_NAME
+) -> str | None:
     """根据 CLI 参数返回 Assisted-by 值。"""
 
     if model is not None and skip:
         raise CommitError("--model and --skip-assisted-by are mutually exclusive")
     if skip:
         return None
+    agent_name = agent.strip()
+    if not agent_name:
+        raise CommitError("--agent must not be empty")
     model_name = model.strip() if model is not None else resolve_model_name()
     if not model_name:
         raise CommitError("--model must not be empty")
-    return f"{AGENT_NAME}:{model_name}"
+    return f"{agent_name}:{model_name}"
 
 
 def run_git(repo: Path, arguments: list[str], *, input_text: str | None = None) -> str:
@@ -432,8 +437,12 @@ def main(
     ] = False,
     model: Annotated[
         str | None,
-        typer.Option("--model", help="显式指定 Codex 模型并跳过自动探测。"),
+        typer.Option("--model", help="显式指定模型并跳过自动探测。"),
     ] = None,
+    agent: Annotated[
+        str,
+        typer.Option("--agent", help=f"Assisted-by 的 Agent 名（默认 {DEFAULT_AGENT_NAME}）。"),
+    ] = DEFAULT_AGENT_NAME,
     skip_assisted_by: Annotated[
         bool,
         typer.Option(
@@ -446,7 +455,7 @@ def main(
 
     try:
         spec = load_spec(spec_file.read_text(encoding="utf-8"))
-        assisted_by = assisted_by_value(model, skip_assisted_by)
+        assisted_by = assisted_by_value(model, skip_assisted_by, agent)
         message = render_message(spec, assisted_by)
         validate_rendered_message(message, assisted_by)
         commit_sha = None

--- a/plugins/dcjanus/skills/repository-workflow/scripts/commit_from_yaml.py
+++ b/plugins/dcjanus/skills/repository-workflow/scripts/commit_from_yaml.py
@@ -30,7 +30,7 @@ from openai_codex.client import CodexClient
 from openai_codex.errors import CodexError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
-DEFAULT_AGENT_NAME = "Codex"
+DEFAULT_AGENT_NAME = "codex"
 CONVENTIONAL_SUBJECT = re.compile(r"^[a-z][a-z0-9-]*(?:\([^\r\n)]+\))?!?: [^\r\n]+$")
 BREAKING_SUBJECT = re.compile(r"^[a-z][a-z0-9-]*(?:\([^\r\n)]+\))?!: .+$")
 BREAKING_PREFIX = "BREAKING CHANGE:"

--- a/plugins/dcjanus/skills/repository-workflow/scripts/tests/test_commit_from_yaml.py
+++ b/plugins/dcjanus/skills/repository-workflow/scripts/tests/test_commit_from_yaml.py
@@ -114,6 +114,19 @@ breaking_change:
         self.assertEqual(got, "Codex:gpt-explicit")
         resolve.assert_not_called()
 
+    def test_uses_explicit_agent_and_model(self) -> None:
+        with mock.patch.object(commit_from_yaml, "resolve_model_name") as resolve:
+            got = commit_from_yaml.assisted_by_value(
+                "deepseek-v4.1-flash", False, "opencode"
+            )
+
+        self.assertEqual(got, "opencode:deepseek-v4.1-flash")
+        resolve.assert_not_called()
+
+    def test_rejects_empty_agent(self) -> None:
+        with self.assertRaisesRegex(commit_from_yaml.CommitError, "agent"):
+            commit_from_yaml.assisted_by_value("gpt-explicit", False, "  ")
+
     def test_skip_assisted_by_avoids_auto_detection(self) -> None:
         with mock.patch.object(commit_from_yaml, "resolve_model_name") as resolve:
             got = commit_from_yaml.assisted_by_value(None, True)

--- a/plugins/dcjanus/skills/repository-workflow/scripts/tests/test_commit_from_yaml.py
+++ b/plugins/dcjanus/skills/repository-workflow/scripts/tests/test_commit_from_yaml.py
@@ -107,9 +107,19 @@ breaking_change:
             message,
         )
 
+    def test_auto_detects_model_with_the_default_agent(self) -> None:
+        with mock.patch.object(commit_from_yaml, "resolve_model_name") as resolve:
+            resolve.return_value = "gpt-current"
+            got = commit_from_yaml.assisted_by_value(None)
+
+        self.assertEqual(got, "Codex:gpt-current")
+        resolve.assert_called_once()
+
     def test_uses_explicit_model_without_auto_detection(self) -> None:
         with mock.patch.object(commit_from_yaml, "resolve_model_name") as resolve:
-            got = commit_from_yaml.assisted_by_value("gpt-explicit", False)
+            got = commit_from_yaml.assisted_by_value(
+                commit_from_yaml.AssistedBy(model="gpt-explicit")
+            )
 
         self.assertEqual(got, "Codex:gpt-explicit")
         resolve.assert_not_called()
@@ -117,7 +127,9 @@ breaking_change:
     def test_uses_explicit_agent_and_model(self) -> None:
         with mock.patch.object(commit_from_yaml, "resolve_model_name") as resolve:
             got = commit_from_yaml.assisted_by_value(
-                "deepseek-v4.1-flash", False, "opencode"
+                commit_from_yaml.AssistedBy(
+                    agent="opencode", model="deepseek-v4.1-flash"
+                )
             )
 
         self.assertEqual(got, "opencode:deepseek-v4.1-flash")
@@ -125,18 +137,46 @@ breaking_change:
 
     def test_rejects_empty_agent(self) -> None:
         with self.assertRaisesRegex(commit_from_yaml.CommitError, "agent"):
-            commit_from_yaml.assisted_by_value("gpt-explicit", False, "  ")
+            commit_from_yaml.assisted_by_value(
+                commit_from_yaml.AssistedBy(agent="  ", model="gpt-explicit")
+            )
 
     def test_skip_assisted_by_avoids_auto_detection(self) -> None:
         with mock.patch.object(commit_from_yaml, "resolve_model_name") as resolve:
-            got = commit_from_yaml.assisted_by_value(None, True)
+            got = commit_from_yaml.assisted_by_value(False)
 
         self.assertIsNone(got)
         resolve.assert_not_called()
 
-    def test_model_and_skip_are_mutually_exclusive(self) -> None:
-        with self.assertRaisesRegex(commit_from_yaml.CommitError, "mutually exclusive"):
-            commit_from_yaml.assisted_by_value("gpt-explicit", True)
+    def test_loads_assisted_by_overrides_from_yaml(self) -> None:
+        spec = commit_from_yaml.load_spec(
+            """
+subject: "chore(commit): load assisted-by overrides"
+assisted_by:
+  agent: opencode
+  model: deepseek-v4.1-flash
+"""
+        )
+
+        self.assertEqual(spec.assisted_by.agent, "opencode")
+        self.assertEqual(spec.assisted_by.model, "deepseek-v4.1-flash")
+
+    def test_loads_assisted_by_skip_from_yaml(self) -> None:
+        spec = commit_from_yaml.load_spec(
+            'subject: "chore(commit): skip assisted-by"\nassisted_by: false\n'
+        )
+
+        self.assertIs(spec.assisted_by, False)
+
+    def test_rejects_unknown_assisted_by_field(self) -> None:
+        with self.assertRaises(ValidationError):
+            commit_from_yaml.load_spec(
+                """
+subject: "chore(commit): reject unknown assisted-by field"
+assisted_by:
+  provider: opencode
+"""
+            )
 
     def test_reads_latest_complete_model_from_rollout(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/plugins/dcjanus/skills/repository-workflow/scripts/tests/test_commit_from_yaml.py
+++ b/plugins/dcjanus/skills/repository-workflow/scripts/tests/test_commit_from_yaml.py
@@ -112,7 +112,7 @@ breaking_change:
             resolve.return_value = "gpt-current"
             got = commit_from_yaml.assisted_by_value(None)
 
-        self.assertEqual(got, "Codex:gpt-current")
+        self.assertEqual(got, "codex:gpt-current")
         resolve.assert_called_once()
 
     def test_uses_explicit_model_without_auto_detection(self) -> None:
@@ -121,7 +121,7 @@ breaking_change:
                 commit_from_yaml.AssistedBy(model="gpt-explicit")
             )
 
-        self.assertEqual(got, "Codex:gpt-explicit")
+        self.assertEqual(got, "codex:gpt-explicit")
         resolve.assert_not_called()
 
     def test_uses_explicit_agent_and_model(self) -> None:


### PR DESCRIPTION
## Why

- `Assisted-by` trailer 过去固定使用 `Codex` 作为 Agent 前缀，在 opencode 等其它 Agent 下会写出错误的来源标识。
- 命令行参数形式的覆盖（model、agent、跳过 trailer）不便随提交一起审查；希望把每次提交的全部输入集中到一个 YAML 文件。

## What

- 新增顶层 `assisted_by` 覆盖项：`agent` 指定 Agent 前缀，`model` 指定模型并跳过自动探测，`assisted_by: false` 省略 trailer。
- 默认 Agent 前缀改为小写 `codex`；未显式指定模型时仍自动探测当前 Codex thread 使用的模型。非 Codex 运行环境下自动探测大概率失败，此时应询问用户所用模型并写入 `assisted_by.model`。
- 移除 `--model`、`--agent`、`--skip-assisted-by` 命令行选项。

## BREAKING CHANGE

- 影响范围：`--model`、`--agent`、`--skip-assisted-by` 不再被接受；未显式设置 `assisted_by.agent` 时，trailer 由 `Assisted-by: Codex:<model>` 变为 `Assisted-by: codex:<model>`。
- 迁移方式：改为在提交 YAML 中通过 `assisted_by` 覆盖项配置，例如：

```yaml
assisted_by:
  agent: opencode
  model: deepseek-v4.1-flash
```

如需保留旧前缀，设置 `assisted_by.agent: Codex`；如需省略 trailer，使用 `assisted_by: false`。
